### PR TITLE
Align action goal lifecycle with ROS1 semantics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
 }
 group 'com.github.rosjava'
-version = '2026.03.18'
+version = '2026.03.28'
 description = 'A pure java version of actionlib'
 sourceCompatibility = JavaVersion.VERSION_21
 

--- a/src/main/java/com/github/rosjava_actionlib/ActionClient.java
+++ b/src/main/java/com/github/rosjava_actionlib/ActionClient.java
@@ -374,9 +374,21 @@ public final class ActionClient<T_ACTION_GOAL extends Message,
      * @see actionlib_msgs.GoalID
      */
     public final void sendCancel(final GoalID goalIDd) {
-        this.goalManager.cancelGoal();
+        this.sendCancelInternal(goalIDd);
+    }
 
+    final boolean sendCancelInternal(final GoalID goalIDd) {
+        Objects.requireNonNull(goalIDd);
+        if (this.cancelPublisher == null) {
+            return false;
+        }
+        final String currentGoalId = this.goalManager.getActionGoal() == null ? null : this.goalManager.getActionGoal().getGoalId();
+        final String cancelledGoalId = goalIDd.getId();
         this.cancelPublisher.publish(goalIDd);
+        if (StringUtils.isNotBlank(cancelledGoalId) && cancelledGoalId.equals(currentGoalId)) {
+            this.goalManager.cancelGoal();
+        }
+        return true;
     }
 
     /**
@@ -507,12 +519,15 @@ public final class ActionClient<T_ACTION_GOAL extends Message,
      */
     private final void gotResult(final T_ACTION_RESULT resultMessage) {
         final ActionResult<T_ACTION_RESULT> actionResultMessage = new ActionResult<>(resultMessage);
-        final GoalID goalID = actionResultMessage.getGoalStatusMessage().getGoalId();
+        final GoalStatus resultGoalStatus = actionResultMessage.getGoalStatusMessage();
+        final GoalID goalId = resultGoalStatus == null ? null : resultGoalStatus.getGoalId();
+        final String currentGoalId = this.goalManager.getActionGoal() == null ? null : this.goalManager.getActionGoal().getGoalId();
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Received result for action:[{}] with result goalId:[{}] while current goalId:[{}]", this.actionName, goalID.getId(), this.goalManager.getActionGoal().getGoalId());
+            final String goalId_id=goalId == null ? null : goalId.getId();
+            LOGGER.trace("Received result for action:[{}] with result goalId:[{}] while current goalId:[{}]", this.actionName,goalId_id , currentGoalId);
         }
-        if (this.goalManager.getActionGoal().getGoalId().equals(goalID.getId())) {
-            this.goalManager.updateStatus(actionResultMessage.getGoalStatusMessage().getStatus());
+        if (goalId != null && StringUtils.isNotBlank(currentGoalId) && currentGoalId.equals(goalId.getId())) {
+            this.goalManager.updateStatus(resultGoalStatus.getStatus());
 
             this.goalManager.resultReceived();
             // Propagate the callback
@@ -522,13 +537,14 @@ public final class ActionClient<T_ACTION_GOAL extends Message,
                 }
             }
             try {
-                this.sendCancel(goalID);
+                this.sendCancel(goalId);
             } catch (final Exception exception) {
                 LOGGER.error("Error while cancelling goal of received result{}", ExceptionUtils.getStackTrace(exception));
             }
         } else {
             if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("Received and ignored GoalId:{} because current client goal id=={}", goalID.getId(), this.goalManager.getActionGoal().getGoalId());
+                final String goalId_id=goalId == null ? null : goalId.getId();
+                LOGGER.trace("Received and ignored GoalId:{} because current client goal id=={}",goalId_id, currentGoalId);
             }
         }
     }
@@ -540,9 +556,9 @@ public final class ActionClient<T_ACTION_GOAL extends Message,
      *                depends on the application.
      */
     private final void gotFeedback(final T_ACTION_FEEDBACK message) {
-        ActionFeedback<T_ACTION_FEEDBACK> af = new ActionFeedback<>(message);
-        if (af.getGoalStatusMessage().getGoalId().getId().equals(goalManager.getActionGoal().getGoalId())) {
-            goalManager.updateStatus(af.getGoalStatusMessage().getStatus());
+        final ActionFeedback<T_ACTION_FEEDBACK> actionFeedback = new ActionFeedback<>(message);
+        if (actionFeedback.getGoalStatusMessage().getGoalId().getId().equals(this.goalManager.getActionGoal().getGoalId())) {
+            this.goalManager.updateStatus(actionFeedback.getGoalStatusMessage().getStatus());
 
             // Propagate the callback
             for (final ActionClientFeedbackListener<T_ACTION_FEEDBACK> actionClientListener : this.callbackFeedbackTargets) {

--- a/src/main/java/com/github/rosjava_actionlib/ActionClientFuture.java
+++ b/src/main/java/com/github/rosjava_actionlib/ActionClientFuture.java
@@ -25,6 +25,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.lang.ref.Cleaner;
+import java.lang.ref.WeakReference;
 import java.util.concurrent.*;
 
 /**
@@ -37,53 +39,76 @@ import java.util.concurrent.*;
 final class ActionClientFuture<T_GOAL extends Message, T_FEEDBACK extends Message, T_RESULT extends Message>
         implements ActionFuture<T_GOAL, T_FEEDBACK, T_RESULT> {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Cleaner CLEANER = Cleaner.create();
     private final GoalID goalid;
     private final CountDownLatch countDownLatch;
     private final ActionClient<T_GOAL, T_FEEDBACK, T_RESULT> actionClient;
+    private final ActionClientFutureListener<T_GOAL, T_FEEDBACK, T_RESULT> actionClientFutureListener;
+    private final Cleaner.Cleanable cleanable;
     private volatile boolean cancelRequested = false;
     private volatile ClientState terminalState = null;
     private T_FEEDBACK latestFeedback = null;
     private T_RESULT result = null;
-    private final ActionClientFutureListener actionClientFutureListener = new ActionClientFutureListener();
 
-    private final class ActionClientFutureListener implements ActionClientResultListener<T_RESULT>, ActionClientFeedbackListener<T_FEEDBACK> {
+    private static final class ListenerCleanup<T_GOAL extends Message, T_FEEDBACK extends Message, T_RESULT extends Message> implements Runnable {
+        private final ActionClient<T_GOAL, T_FEEDBACK, T_RESULT> actionClient;
+        private final ActionClientFutureListener<T_GOAL, T_FEEDBACK, T_RESULT> listener;
 
-        public final void feedbackReceived(final T_FEEDBACK t_feedback) {
-            final ActionFeedback<T_FEEDBACK> actionFeedback = new ActionFeedback(t_feedback);
-            if (ActionClientFuture.this.LOGGER.isTraceEnabled()) {
-                ActionClientFuture.this.LOGGER.trace("Received feedback for goalId: " + actionFeedback.getGoalStatusMessage().getGoalId().getId());
-            }
-            if (actionFeedback.getGoalStatusMessage().getGoalId().getId().equals(ActionClientFuture.this.goalid.getId())) {
-                ActionClientFuture.this.latestFeedback = t_feedback;
-            }
-
+        private ListenerCleanup(final ActionClient<T_GOAL, T_FEEDBACK, T_RESULT> actionClient,
+                                final ActionClientFutureListener<T_GOAL, T_FEEDBACK, T_RESULT> listener) {
+            this.actionClient = actionClient;
+            this.listener = listener;
         }
 
-        /**
-         * @param t_result
-         */
+        @Override
+        public final void run() {
+            this.actionClient.removeActionClientFeedbackListener(this.listener);
+            this.actionClient.removeActionClientResultListener(this.listener);
+        }
+    }
+
+    private static final class ActionClientFutureListener<T_GOAL extends Message, T_FEEDBACK extends Message, T_RESULT extends Message>
+            implements ActionClientResultListener<T_RESULT>, ActionClientFeedbackListener<T_FEEDBACK> {
+        private final WeakReference<ActionClientFuture<T_GOAL, T_FEEDBACK, T_RESULT>> ownerReference;
+
+        private ActionClientFutureListener(final ActionClientFuture<T_GOAL, T_FEEDBACK, T_RESULT> owner) {
+            this.ownerReference = new WeakReference<>(owner);
+        }
+
+        @Override
+        public final void feedbackReceived(final T_FEEDBACK t_feedback) {
+            final ActionClientFuture<T_GOAL, T_FEEDBACK, T_RESULT> owner = this.ownerReference.get();
+            if (owner == null) {
+                return;
+            }
+            final ActionFeedback<T_FEEDBACK> actionFeedback = new ActionFeedback<>(t_feedback);
+            if (ActionClientFuture.LOGGER.isTraceEnabled()) {
+                ActionClientFuture.LOGGER.trace("Received feedback for goalId: {}", actionFeedback.getGoalStatusMessage().getGoalId().getId());
+            }
+            if (actionFeedback.getGoalStatusMessage().getGoalId().getId().equals(owner.goalid.getId())) {
+                owner.latestFeedback = t_feedback;
+            }
+        }
+
         @Override
         public final void resultReceived(final T_RESULT t_result) {
-            final ActionResult resultWrapper = new ActionResult(t_result);
-            final String goalId=resultWrapper.getGoalStatusMessage().getGoalId().getId();
-            if (ActionClientFuture.this.LOGGER.isDebugEnabled()) {
-                ActionClientFuture.this.LOGGER.debug("Received result for goalId: " + goalId);
+            final ActionClientFuture<T_GOAL, T_FEEDBACK, T_RESULT> owner = this.ownerReference.get();
+            if (owner == null) {
+                return;
             }
-            if (goalId.equals(ActionClientFuture.this.goalid.getId())) {
-                ActionClientFuture.this.result = t_result;
-                ActionClientFuture.this.terminalState = ClientState.DONE;
-                ActionClientFuture.this.disconnect();
-                ActionClientFuture.this.countDownLatch.countDown();
-
+            final ActionResult<T_RESULT> resultWrapper = new ActionResult<>(t_result);
+            final String goalId = resultWrapper.getGoalStatusMessage().getGoalId().getId();
+            if (ActionClientFuture.LOGGER.isDebugEnabled()) {
+                ActionClientFuture.LOGGER.debug("Received result for goalId: {}", goalId);
+            }
+            if (goalId.equals(owner.goalid.getId())) {
+                owner.completeWithResult(t_result);
             } else {
-                if (LOGGER.isErrorEnabled()) {
-                    LOGGER.error("Result with Unknown id:" + goalId + ", waiting for goalId:" + ActionClientFuture.this.goalid.getId());
+                if (ActionClientFuture.LOGGER.isErrorEnabled()) {
+                    ActionClientFuture.LOGGER.error("Result with Unknown id:{}, waiting for goalId:{}", goalId, owner.goalid.getId());
                 }
             }
-
-
         }
-
     }
 
     /**
@@ -99,7 +124,7 @@ final class ActionClientFuture<T_GOAL extends Message, T_FEEDBACK extends Messag
         final GoalID goalId = actionClient.getGoalId(goal);
         final ActionClientFuture<T_GOAL, T_FEEDBACK, T_RESULT> actionClientFuture = new ActionClientFuture<>(actionClient, goalId);
         if (LOGGER.isWarnEnabled() && actionClient.isActive()) {
-            LOGGER.warn("current goal STATE:" + actionClient.getGoalState() + "=" + actionClient.getGoalState().getValue());
+            LOGGER.warn("current goal STATE:{}={}", actionClient.getGoalState(), actionClient.getGoalState().getValue());
         }
         actionClient.addActionClientFeedbackListener((ActionClientFeedbackListener<T_FEEDBACK>) actionClientFuture.actionClientFutureListener);
         actionClient.addActionClientResultListener((ActionClientResultListener<T_RESULT>) actionClientFuture.actionClientFutureListener);
@@ -117,6 +142,8 @@ final class ActionClientFuture<T_GOAL extends Message, T_FEEDBACK extends Messag
         this.actionClient = actionClient;
         this.goalid = goalID;
         this.countDownLatch = new CountDownLatch(1);
+        this.actionClientFutureListener = new ActionClientFutureListener<>(this);
+        this.cleanable = CLEANER.register(this, new ListenerCleanup<>(actionClient, this.actionClientFutureListener));
     }
 
 
@@ -145,9 +172,8 @@ final class ActionClientFuture<T_GOAL extends Message, T_FEEDBACK extends Messag
      */
     @Override
     public final boolean cancel(final boolean mayInterruptIfRunning) {
-        this.cancelRequested = true;
-        this.actionClient.sendCancel(this.goalid);
-        return true;
+        this.cancelRequested = this.actionClient.sendCancelInternal(this.goalid);
+        return this.cancelRequested;
     }
 
     /**
@@ -191,8 +217,14 @@ final class ActionClientFuture<T_GOAL extends Message, T_FEEDBACK extends Messag
      *
      */
     private final void disconnect() {
-        this.actionClient.removeActionClientFeedbackListener(this.actionClientFutureListener);
-        this.actionClient.removeActionClientResultListener(this.actionClientFutureListener);
+        this.cleanable.clean();
+    }
+
+    private void completeWithResult(final T_RESULT t_result) {
+        this.result = t_result;
+        this.terminalState = ClientState.DONE;
+        this.disconnect();
+        this.countDownLatch.countDown();
     }
 
     /**

--- a/src/main/java/com/github/rosjava_actionlib/ActionResult.java
+++ b/src/main/java/com/github/rosjava_actionlib/ActionResult.java
@@ -33,26 +33,32 @@ public final class ActionResult<T_ACTION_RESULT extends Message> {
         this.actionResultMessage = msg;
     }
 
-    public Header getHeaderMessage() {
-        Header header = null;
+    public final Header getHeaderMessage() {
+        final Header header;
         if (this.actionResultMessage != null) {
             header = ActionLibMessagesUtils.getSubMessageFromMessage(this.actionResultMessage, "getHeader");
+        } else {
+            header = null;
         }
         return header;
     }
 
-    public GoalStatus getGoalStatusMessage() {
-        GoalStatus goalStatus = null;
+    public final GoalStatus getGoalStatusMessage() {
+        final GoalStatus goalStatus;
         if (this.actionResultMessage != null) {
             goalStatus = ActionLibMessagesUtils.getSubMessageFromMessage(this.actionResultMessage, "getStatus");
+        } else {
+            goalStatus = null;
         }
         return goalStatus;
     }
 
-    public Message getResultMessage() {
-        Message resultMessage= null;
+    public final Message getResultMessage() {
+        final Message resultMessage;
         if (this.actionResultMessage != null) {
             resultMessage = ActionLibMessagesUtils.getSubMessageFromMessage(this.actionResultMessage, "getResult");
+        } else {
+            resultMessage = null;
         }
         return resultMessage;
     }

--- a/src/main/java/com/github/rosjava_actionlib/ActionServer.java
+++ b/src/main/java/com/github/rosjava_actionlib/ActionServer.java
@@ -49,6 +49,8 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
     //default status_frequency is 5Hz for python and cpp
     private static final long DEFAULT_STATUS_TICK_PERIOD_MILLIS = 200;
     private static final long DEFAULT_STATUS_TICK_DELAY_MILLIS = 200;
+    private static final long DEFAULT_TERMINAL_STATUS_RETENTION_MILLIS = 5000;
+    private static final long TERMINAL_STATUS_RETENTION_NOT_SCHEDULED_NANOS = Long.MIN_VALUE;
 
     /**
      * Keeps the status of each goal
@@ -59,6 +61,7 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
         private final T_ACTION_GOAL_TYPE goal;
         private final GoalID goalId;
         private final ServerStateMachine stateMachine = new ServerStateMachine();
+        private volatile long terminalStatusRetentionDeadlineNanos = TERMINAL_STATUS_RETENTION_NOT_SCHEDULED_NANOS;
 
         private ServerGoal(final T_ACTION_GOAL_TYPE goal, final GoalID goalId) {
             this.goal = goal;
@@ -73,9 +76,9 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
     private final String actionName;
     private final ActionServerListener<T_ACTION_GOAL> actionServerListener;
     private final MessageFactory messageFactory;
+    private final long terminalStatusRetentionNanos;
     private final Timer statusTick = new Timer();
     private final ConcurrentHashMap<String, ServerGoal<T_ACTION_GOAL>> goalIdToGoalStatusMap = new ConcurrentHashMap<>();
-    private final Set<String> goalIdsPendingStatusPublicationRemoval = ConcurrentHashMap.newKeySet();
 
     //Non Final
     private Subscriber<T_ACTION_GOAL> goalSubscriber = null;
@@ -104,12 +107,26 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
             , final String actionGoalType
             , final String actionFeedbackType
             , final String actionResultType) {
+        this(connectedNode, actionServerListener, actionName, actionGoalType, actionFeedbackType, actionResultType,
+                DEFAULT_TERMINAL_STATUS_RETENTION_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    ActionServer(final ConnectedNode connectedNode
+            , final ActionServerListener<T_ACTION_GOAL> actionServerListener
+            , final String actionName
+            , final String actionGoalType
+            , final String actionFeedbackType
+            , final String actionResultType
+            , final long terminalStatusRetention
+            , final TimeUnit terminalStatusRetentionTimeUnit) {
         Objects.requireNonNull(connectedNode);
         Objects.requireNonNull(actionServerListener);
+        Objects.requireNonNull(terminalStatusRetentionTimeUnit);
         Preconditions.checkArgument(StringUtils.isNotBlank(actionName));
         Preconditions.checkArgument(StringUtils.isNotBlank(actionGoalType));
         Preconditions.checkArgument(StringUtils.isNotBlank(actionFeedbackType));
         Preconditions.checkArgument(StringUtils.isNotBlank(actionResultType));
+        Preconditions.checkArgument(terminalStatusRetention >= 0);
         this.actionServerListener = actionServerListener;
 
         this.actionName = actionName;
@@ -117,6 +134,7 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
         this.actionFeedbackType = actionFeedbackType;
         this.actionResultType = actionResultType;
         this.messageFactory = connectedNode.getDefaultMessageFactory();
+        this.terminalStatusRetentionNanos = terminalStatusRetentionTimeUnit.toNanos(terminalStatusRetention);
         this.connect(connectedNode);
     }
 
@@ -147,29 +165,42 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
      * @param result The action result message to send.
      */
     public final void sendResult(final T_ACTION_RESULT result) {
+        final GoalStatus goalStatus = this.synchronizeResultGoalStatus(this.getResultGoalStatus(result));
         if (LOGGER.isTraceEnabled()) {
-            final GoalStatus goalStatus = ActionLibMessagesUtils.getSubMessageFromMessage(result, "getStatus");
             final String goalId = goalStatus != null && goalStatus.getGoalId() != null ? goalStatus.getGoalId().getId() : null;
             LOGGER.trace("Publishing result on action:[{}] with goalId:[{}]", this.actionName, goalId);
         }
         this.resultPublisher.publish(result);
-        this.evictGoalForResult(result);
+        if (goalStatus != null && isTerminalStatus(goalStatus.getStatus())) {
+            this.sendStatusTick();
+        }
     }
 
     private final void evictGoal(final String goalId) {
         if (goalId == null) {
             return;
         }
-        this.goalIdsPendingStatusPublicationRemoval.remove(goalId);
         this.goalIdToGoalStatusMap.remove(goalId);
     }
 
-    private final void evictGoalForResult(final T_ACTION_RESULT result) {
-        final GoalStatus goalStatus = ActionLibMessagesUtils.getSubMessageFromMessage(result, "getStatus");
+    private final GoalStatus getResultGoalStatus(final T_ACTION_RESULT result) {
+        return ActionLibMessagesUtils.getSubMessageFromMessage(result, "getStatus");
+    }
+
+    private final GoalStatus synchronizeResultGoalStatus(final GoalStatus goalStatus) {
         if (goalStatus == null || goalStatus.getGoalId() == null) {
-            return;
+            return goalStatus;
         }
-        this.evictGoal(goalStatus.getGoalId().getId());
+        final String goalId = goalStatus.getGoalId().getId();
+        final ServerGoal<T_ACTION_GOAL> serverGoal = this.goalIdToGoalStatusMap.get(goalId);
+        if (serverGoal == null) {
+            return goalStatus;
+        }
+        goalStatus.getGoalId().setId(serverGoal.goalId.getId());
+        goalStatus.getGoalId().setStamp(serverGoal.goalId.getStamp());
+        final byte trackedStatus = serverGoal.stateMachine.getState();
+        goalStatus.setStatus(trackedStatus);
+        return goalStatus;
     }
 
     static final boolean isTerminalStatus(final byte status) {
@@ -178,13 +209,6 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
                 || status == GoalStatus.PREEMPTED
                 || status == GoalStatus.SUCCEEDED
                 || status == GoalStatus.ABORTED;
-    }
-
-    private final void markGoalForRemovalAfterStatusPublication(final String goalIdString) {
-        if (goalIdString == null) {
-            return;
-        }
-        this.goalIdsPendingStatusPublicationRemoval.add(goalIdString);
     }
 
     /**
@@ -399,20 +423,35 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
      */
     public final synchronized void sendStatusTick() {
         try {
+            final long nowNanos = System.nanoTime();
             final GoalStatusArray goalStatusArray = this.messageFactory.newFromType(GoalStatusArray._TYPE);
             final List<GoalStatus> goalStatusList = new ArrayList<>(this.goalIdToGoalStatusMap.size());
+            final List<String> goalIdsToEvict = new ArrayList<>();
             goalStatusArray.setStatusList(goalStatusList);
 
-            for (final ServerGoal<T_ACTION_GOAL> serverGoal : this.goalIdToGoalStatusMap.values()) {
+            for (final Map.Entry<String, ServerGoal<T_ACTION_GOAL>> entry : this.goalIdToGoalStatusMap.entrySet()) {
+                final String goalId = entry.getKey();
+                final ServerGoal<T_ACTION_GOAL> serverGoal = entry.getValue();
+                final byte goalState = serverGoal.stateMachine.getState();
+                if (isTerminalStatus(goalState)) {
+                    final long retentionDeadlineNanos = serverGoal.terminalStatusRetentionDeadlineNanos;
+                    if (retentionDeadlineNanos == TERMINAL_STATUS_RETENTION_NOT_SCHEDULED_NANOS) {
+                        serverGoal.terminalStatusRetentionDeadlineNanos = nowNanos + this.terminalStatusRetentionNanos;
+                    } else if (retentionDeadlineNanos <= nowNanos) {
+                        goalIdsToEvict.add(goalId);
+                        continue;
+                    }
+                } else {
+                    serverGoal.terminalStatusRetentionDeadlineNanos = TERMINAL_STATUS_RETENTION_NOT_SCHEDULED_NANOS;
+                }
                 final GoalStatus goalStatus = this.messageFactory.newFromType(GoalStatus._TYPE);
                 goalStatus.setGoalId(serverGoal.goalId);
-                goalStatus.setStatus((byte) serverGoal.stateMachine.getState());
+                goalStatus.setStatus(goalState);
                 goalStatusList.add(goalStatus);
             }
 
 
             this.sendStatus(goalStatusArray);
-            final List<String> goalIdsToEvict = new ArrayList<>(this.goalIdsPendingStatusPublicationRemoval);
             goalIdsToEvict.forEach(this::evictGoal);
 
         } catch (final Exception exception) {
@@ -526,10 +565,7 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
 
     private final void recordTransitionEvent(final String goalIdString, final int event) {
         this.goalIdToGoalStatusMap.computeIfPresent(goalIdString, (id, value) -> {
-            final byte nextStatus = (byte) value.stateMachine.transition(event);
-            if (isTerminalStatus(nextStatus)) {
-                this.markGoalForRemovalAfterStatusPublication(goalIdString);
-            }
+            value.stateMachine.transition(event);
             return value;
         });
     }

--- a/src/main/java/com/github/rosjava_actionlib/ClientState.java
+++ b/src/main/java/com/github/rosjava_actionlib/ClientState.java
@@ -72,9 +72,11 @@ public enum ClientState {
      * @return
      */
     public final boolean isAmong(final ClientState... state) {
-        boolean result = false;
+        final boolean result;
         if (state != null) {
             result = Arrays.stream(state).filter(this::equals).findAny().isPresent();
+        } else {
+            result = false;
         }
         return result;
     }

--- a/src/main/java/com/github/rosjava_actionlib/ClientStateMachine.java
+++ b/src/main/java/com/github/rosjava_actionlib/ClientStateMachine.java
@@ -21,7 +21,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -66,7 +69,7 @@ final class ClientStateMachine {
     final synchronized void setState(final ClientState state) {
         Objects.requireNonNull(state);
         if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("ClientStateMachine - State changed from " + this.state + " to " + state);
+            LOGGER.info("ClientStateMachine - State changed from {} to {}", this.state, state);
         }
         this.state = state;
     }
@@ -99,13 +102,13 @@ final class ClientStateMachine {
         if (!nextStates.isEmpty()) {
             if (nextStates.size() == 1 && nextStates.contains(this.state)) {
                 if (this.LOGGER.isTraceEnabled()) {
-                    this.LOGGER.trace("Maintaining ClientState:" + this.state + " for GoalStatus:" + goalStatus);
+                    this.LOGGER.trace("Maintaining ClientState:{} for GoalStatus:{}", this.state, goalStatus);
                 }
             } else {
                 for (int i = 0; i < nextStates.size(); i++) {
                     final ClientState state = nextStates.get(i);
                     if (this.LOGGER.isTraceEnabled()) {
-                        this.LOGGER.trace("Transition" + (i + 1) + " of " + nextStates.size() + " from ClientState:" + this.state + " to ClientState: " + state + " on GoalStatus:" + goalStatus);
+                        this.LOGGER.trace("Transition{} of {} from ClientState:{} to ClientState: {} on GoalStatus:{}", i + 1, nextStates.size(), this.state, state, goalStatus);
                     }
 
                     this.state = state;

--- a/src/main/java/com/github/rosjava_actionlib/TopicParticipantListener.java
+++ b/src/main/java/com/github/rosjava_actionlib/TopicParticipantListener.java
@@ -3,21 +3,13 @@ package com.github.rosjava_actionlib;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
-import org.ros.internal.message.Message;
-import org.ros.internal.node.topic.PublisherIdentifier;
-import org.ros.internal.node.topic.SubscriberIdentifier;
-import org.ros.internal.node.topic.TopicIdentifier;
 import org.ros.internal.node.topic.TopicParticipant;
 import org.ros.master.client.MasterStateClient;
-import org.ros.master.client.TopicSystemState;
 import org.ros.node.ConnectedNode;
-import org.ros.node.topic.Publisher;
-import org.ros.node.topic.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -113,7 +105,7 @@ abstract class TopicParticipantListener {
                 return this.isRegistered();
             } catch (final InterruptedException interruptedException) {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Interrupted while:" + this.toString() + " after:" + stopwatch.elapsed(TimeUnit.MILLISECONDS) + " " + TimeUnit.MILLISECONDS);
+                    LOGGER.trace("Interrupted while:{} after:{} {}", this.toString(), stopwatch.elapsed(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
                 }
                 throw interruptedException;
             }

--- a/src/main/java/com/github/rosjava_actionlib/TopicPublisherListener.java
+++ b/src/main/java/com/github/rosjava_actionlib/TopicPublisherListener.java
@@ -3,7 +3,6 @@ package com.github.rosjava_actionlib;
 import com.google.common.base.Stopwatch;
 import org.ros.internal.message.Message;
 import org.ros.internal.node.topic.SubscriberIdentifier;
-import org.ros.internal.node.topic.TopicIdentifier;
 import org.ros.master.client.MasterStateClient;
 import org.ros.master.client.TopicSystemState;
 import org.ros.node.ConnectedNode;
@@ -51,7 +50,7 @@ final class TopicPublisherListener<T extends Message> extends TopicParticipantLi
                 break;
             } catch (final InterruptedException interruptedException) {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Interrupted while:" + this.toString() + " after:" + stopwatch.elapsed(timeUnit) + " " + timeUnit.name());
+                    LOGGER.trace("Interrupted while:{} after:{} {}", this.toString(), stopwatch.elapsed(timeUnit), timeUnit.name());
                 }
                 throw interruptedException;
             }
@@ -101,7 +100,7 @@ final class TopicPublisherListener<T extends Message> extends TopicParticipantLi
         final long subscribers = this.knownSubscribersCount.get();
         this.subscriberConnectionNoticed.countDown();
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("New publisher for Topic:" + publisher.getTopicName() + " type:" + publisher.getTopicMessageType() + " total subscribers:" + subscribers);
+            LOGGER.trace("New publisher for Topic:{} type:{} total subscribers:{}", publisher.getTopicName(), publisher.getTopicMessageType(), subscribers);
         }
         this.callOnceOnConnection();
 

--- a/src/main/java/com/github/rosjava_actionlib/TopicSubscriberListener.java
+++ b/src/main/java/com/github/rosjava_actionlib/TopicSubscriberListener.java
@@ -3,7 +3,6 @@ package com.github.rosjava_actionlib;
 import com.google.common.base.Stopwatch;
 import org.ros.internal.message.Message;
 import org.ros.internal.node.topic.PublisherIdentifier;
-import org.ros.internal.node.topic.TopicIdentifier;
 import org.ros.master.client.MasterStateClient;
 import org.ros.master.client.TopicSystemState;
 import org.ros.node.ConnectedNode;
@@ -49,7 +48,7 @@ final class TopicSubscriberListener<T extends Message> extends TopicParticipantL
                 break;
             } catch (final InterruptedException interruptedException) {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Interrupted while:" + this.toString() + " after:" + stopwatch.elapsed(timeUnit) + " " + timeUnit.name());
+                    LOGGER.trace("Interrupted while:{} after:{} {}", this.toString(), stopwatch.elapsed(timeUnit), timeUnit.name());
                 }
                 throw interruptedException;
             }
@@ -101,7 +100,7 @@ final class TopicSubscriberListener<T extends Message> extends TopicParticipantL
         final long publishers = this.knownPublishersCount.incrementAndGet();
         this.publisherConnectionNoticed.countDown();
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("New publisher for Topic:" + publisherIdentifier.getTopicName() + " node:" + publisherIdentifier.getNodeName() + " type:" + subscriber.getTopicMessageType() + " total publishers:" + publishers);
+            LOGGER.trace("New publisher for Topic:{} node:{} type:{} total publishers:{}", publisherIdentifier.getTopicName(), publisherIdentifier.getNodeName(), subscriber.getTopicMessageType(), publishers);
         }
         this.callOnceOnConnection();
     }

--- a/src/test/java/com/github/rosjava_actionlib/ActionClientFutureLifecycleTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionClientFutureLifecycleTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rosjava_actionlib;
+
+import actionlib_msgs.GoalID;
+import actionlib_tutorials.FibonacciActionFeedback;
+import actionlib_tutorials.FibonacciActionGoal;
+import actionlib_tutorials.FibonacciActionResult;
+import eu.test.utils.RosExecutor;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.ros.namespace.GraphName;
+import org.ros.node.AbstractNodeMain;
+import org.ros.node.ConnectedNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Spyros Koukas
+ */
+public class ActionClientFutureLifecycleTest extends BaseTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final long TIMEOUT = 30;
+    private static final TimeUnit TIME_UNIT = TimeUnit.SECONDS;
+
+    private FutureBasedClientNode futureBasedClientNode = null;
+    private NeverCompletingActionLibServer neverCompletingActionLibServer = null;
+
+    @Test
+    public final void testAbandonedFutureCanBeGarbageCollectedAndUnregistered() {
+        try {
+            final ActionClient<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> actionClient =
+                    this.futureBasedClientNode.getActionClient();
+            final int initialResultListenerCount = getListenerCount(actionClient, "callbackResultTargets");
+            final int initialFeedbackListenerCount = getListenerCount(actionClient, "callbackFeedbackTargets");
+
+            ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> createdFuture =
+                    this.futureBasedClientNode.invoke(TestInputs.TEST_INPUT);
+            final WeakReference<ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult>> weakReference =
+                    new WeakReference<>(createdFuture);
+
+            Assert.assertEquals(initialResultListenerCount + 1, getListenerCount(actionClient, "callbackResultTargets"));
+            Assert.assertEquals(initialFeedbackListenerCount + 1, getListenerCount(actionClient, "callbackFeedbackTargets"));
+
+            createdFuture = null;
+            waitForGarbageCollection(weakReference);
+
+            Assert.assertNull("The future should be garbage collectable after user code drops it", weakReference.get());
+            Assert.assertEquals("Result listener registrations should be removed when the future is abandoned",
+                    initialResultListenerCount, getListenerCount(actionClient, "callbackResultTargets"));
+            Assert.assertEquals("Feedback listener registrations should be removed when the future is abandoned",
+                    initialFeedbackListenerCount, getListenerCount(actionClient, "callbackFeedbackTargets"));
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
+    }
+
+    @Override
+    void beforeCustom(final RosExecutor rosExecutor, final Optional<String> rosMasterUri) {
+        try {
+            Assume.assumeNotNull(rosExecutor);
+            Assume.assumeTrue(rosMasterUri.isPresent());
+
+            this.neverCompletingActionLibServer = new NeverCompletingActionLibServer();
+            this.futureBasedClientNode = new FutureBasedClientNode();
+
+            rosExecutor.startNodeMain(this.neverCompletingActionLibServer, this.neverCompletingActionLibServer.getDefaultNodeName().toString(), rosMasterUri.get());
+            Assert.assertTrue("Server could not connect", this.neverCompletingActionLibServer.waitForStart(TIMEOUT, TIME_UNIT));
+
+            rosExecutor.startNodeMain(this.futureBasedClientNode, this.futureBasedClientNode.getDefaultNodeName().toString(), rosMasterUri.get());
+            final boolean clientStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT, TIME_UNIT);
+            Assume.assumeTrue("Client could not connect", clientStarted);
+        } catch (final Exception exception) {
+            Assume.assumeNoException(exception);
+        }
+    }
+
+    @Override
+    void afterCustom(final RosExecutor rosExecutor) {
+        try {
+            rosExecutor.stopNodeMain(this.neverCompletingActionLibServer);
+        } catch (final Exception exception) {
+            LOGGER.error(ExceptionUtils.getStackTrace(exception));
+        }
+        try {
+            rosExecutor.stopNodeMain(this.futureBasedClientNode);
+        } catch (final Exception exception) {
+            LOGGER.error(ExceptionUtils.getStackTrace(exception));
+        }
+        this.futureBasedClientNode = null;
+        this.neverCompletingActionLibServer = null;
+    }
+
+    private static int getListenerCount(final ActionClient<?, ?, ?> actionClient, final String fieldName) {
+        try {
+            final Field field = ActionClient.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return ((List<?>) field.get(actionClient)).size();
+        } catch (final Exception exception) {
+            throw new AssertionError(exception);
+        }
+    }
+
+    private static void waitForGarbageCollection(final WeakReference<?> weakReference) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (weakReference.get() != null && System.nanoTime() < deadline) {
+            System.gc();
+            Thread.sleep(50);
+        }
+    }
+
+    private static final class NeverCompletingActionLibServer extends AbstractNodeMain implements ActionServerListener<FibonacciActionGoal> {
+        private final CountDownLatch startCountDownLatch = new CountDownLatch(1);
+        private ActionServer<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> actionServer = null;
+
+        @Override
+        public GraphName getDefaultNodeName() {
+            return GraphName.of(FibonacciGraphNames.SERVER_NODE_GRAPH_NAME);
+        }
+
+        @Override
+        public void onStart(final ConnectedNode connectedNode) {
+            this.actionServer = new ActionServer<>(connectedNode, this, FibonacciGraphNames.ACTION_GRAPH_NAME,
+                    FibonacciActionGoal._TYPE, FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE);
+            this.startCountDownLatch.countDown();
+        }
+
+        @Override
+        public void goalReceived(final FibonacciActionGoal goal) {
+        }
+
+        @Override
+        public void cancelReceived(final GoalID goalId) {
+        }
+
+        @Override
+        public Optional<Boolean> acceptGoal(final FibonacciActionGoal goal) {
+            this.actionServer.setAccepted(goal.getGoalId().getId());
+            return Optional.empty();
+        }
+
+        public boolean waitForStart(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
+            return this.startCountDownLatch.await(timeout, timeUnit);
+        }
+    }
+}

--- a/src/test/java/com/github/rosjava_actionlib/ActionLibMessagesUtilsTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionLibMessagesUtilsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
 import org.junit.Assert;

--- a/src/test/java/com/github/rosjava_actionlib/ActionServerResultStatusCompatibilityTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionServerResultStatusCompatibilityTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rosjava_actionlib;
+
+import actionlib_msgs.GoalStatus;
+import actionlib_tutorials.FibonacciActionFeedback;
+import actionlib_tutorials.FibonacciActionGoal;
+import actionlib_tutorials.FibonacciActionResult;
+import com.google.common.base.Stopwatch;
+import eu.test.utils.RosExecutor;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class ActionServerResultStatusCompatibilityTest extends BaseTest {
+    private static final long TIMEOUT = 30;
+    private static final TimeUnit TIME_UNIT = TimeUnit.SECONDS;
+
+    private FutureBasedClientNode futureBasedClientNode = null;
+    private FibonacciActionLibServer fibonacciActionLibServer = null;
+
+    @Test
+    public final void resultUsesTrackedTerminalStatusWhenServerDoesNotPopulateItExplicitly() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        final CountDownLatch terminalStatusReceived = new CountDownLatch(1);
+        final AtomicReference<Byte> terminalStatus = new AtomicReference<>();
+
+        this.futureBasedClientNode.getActionClient().addActionClientStatusListener(statusArray -> statusArray.getStatusList().stream()
+                .filter(goalStatus -> goalStatus != null)
+                .map(goalStatus -> goalStatus.getStatus())
+                .filter(ActionServer::isTerminalStatus)
+                .findFirst()
+                .ifPresent(status -> {
+                    terminalStatus.compareAndSet(null, status);
+                    terminalStatusReceived.countDown();
+                }));
+
+        try {
+            final boolean serverStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT, TIME_UNIT);
+            Assert.assertTrue("Was not connected. Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT, serverStarted);
+
+            final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> resultFuture =
+                    this.futureBasedClientNode.invoke(TestInputs.TEST_INPUT);
+
+            final FibonacciActionResult result = resultFuture.get(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertNotNull("Null Result", result);
+            Assert.assertTrue("Result was wrong", Arrays.equals(result.getResult().getSequence(), TestInputs.TEST_CORRECT_OUTPUT));
+            Assert.assertEquals("Result should inherit tracked SUCCEEDED status", GoalStatus.SUCCEEDED, result.getStatus().getStatus());
+
+            final boolean statusReceived = terminalStatusReceived.await(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertTrue("Expected a terminal /status publication after the result", statusReceived);
+            Assert.assertEquals("Expected SUCCEEDED terminal status", Byte.valueOf(GoalStatus.SUCCEEDED), terminalStatus.get());
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
+    }
+
+    @Override
+    final void beforeCustom(final RosExecutor rosExecutor, final Optional<String> rosMasterUri) {
+        try {
+            Assume.assumeNotNull(rosExecutor);
+            Assume.assumeTrue(rosMasterUri.isPresent());
+            final Stopwatch stopwatch = Stopwatch.createStarted();
+            this.fibonacciActionLibServer = new FibonacciActionLibServer(false);
+            this.futureBasedClientNode = new FutureBasedClientNode();
+
+            rosExecutor.startNodeMain(this.fibonacciActionLibServer, this.fibonacciActionLibServer.getDefaultNodeName().toString(), rosMasterUri.get());
+            final boolean serverStarted = this.fibonacciActionLibServer.waitForStart(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertTrue("Server Could not connect", serverStarted);
+
+            rosExecutor.startNodeMain(this.futureBasedClientNode, this.futureBasedClientNode.getDefaultNodeName().toString(), rosMasterUri.get());
+            final boolean clientStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assume.assumeTrue("Client started. " + "Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT + " " + TIME_UNIT, clientStarted);
+        } catch (final Exception exception) {
+            Assume.assumeNoException(exception);
+        }
+    }
+
+    @Override
+    final void afterCustom(final RosExecutor rosExecutor) {
+        try {
+            rosExecutor.stopNodeMain(this.fibonacciActionLibServer);
+        } catch (final Exception ignored) {
+        }
+        try {
+            rosExecutor.stopNodeMain(this.futureBasedClientNode);
+        } catch (final Exception ignored) {
+        }
+        this.futureBasedClientNode = null;
+        this.fibonacciActionLibServer = null;
+    }
+}

--- a/src/test/java/com/github/rosjava_actionlib/ActionServerTerminalStatusRetentionTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionServerTerminalStatusRetentionTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rosjava_actionlib;
+
+import actionlib_tutorials.FibonacciActionFeedback;
+import actionlib_tutorials.FibonacciActionGoal;
+import actionlib_tutorials.FibonacciActionResult;
+import com.google.common.base.Stopwatch;
+import eu.test.utils.RosExecutor;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public final class ActionServerTerminalStatusRetentionTest extends BaseTest {
+    private static final long TIMEOUT = 30;
+    private static final TimeUnit TIME_UNIT = TimeUnit.SECONDS;
+    private static final long TERMINAL_STATUS_RETENTION_MILLIS = 1000;
+
+    private FutureBasedClientNode futureBasedClientNode = null;
+    private FibonacciActionLibServer fibonacciActionLibServer = null;
+
+    @Test
+    public final void terminalGoalsRemainTrackedUntilRetentionTimeoutExpires() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            final boolean serverStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT, TIME_UNIT);
+            Assert.assertTrue("Was not connected. Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT, serverStarted);
+
+            final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> resultFuture =
+                    this.futureBasedClientNode.invoke(TestInputs.TEST_INPUT);
+
+            final FibonacciActionResult result = resultFuture.get(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertNotNull("Null Result", result);
+            final String goalId = result.getStatus().getGoalId().getId();
+            final Map<?, ?> trackedGoals = this.getTrackedGoalsMap();
+
+            Assert.assertTrue("Terminal goal should remain tracked for additional status heartbeats", trackedGoals.containsKey(goalId));
+            this.waitUntil(() -> !trackedGoals.containsKey(goalId), TERMINAL_STATUS_RETENTION_MILLIS + 2000);
+            Assert.assertFalse("Terminal goal should be evicted after the retention timeout", trackedGoals.containsKey(goalId));
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
+    }
+
+    @Override
+    final void beforeCustom(final RosExecutor rosExecutor, final Optional<String> rosMasterUri) {
+        try {
+            Assume.assumeNotNull(rosExecutor);
+            Assume.assumeTrue(rosMasterUri.isPresent());
+            final Stopwatch stopwatch = Stopwatch.createStarted();
+            this.fibonacciActionLibServer = new FibonacciActionLibServer(true, TERMINAL_STATUS_RETENTION_MILLIS, TimeUnit.MILLISECONDS);
+            this.futureBasedClientNode = new FutureBasedClientNode();
+
+            rosExecutor.startNodeMain(this.fibonacciActionLibServer, this.fibonacciActionLibServer.getDefaultNodeName().toString(), rosMasterUri.get());
+            final boolean serverStarted = this.fibonacciActionLibServer.waitForStart(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertTrue("Server Could not connect", serverStarted);
+
+            rosExecutor.startNodeMain(this.futureBasedClientNode, this.futureBasedClientNode.getDefaultNodeName().toString(), rosMasterUri.get());
+            final boolean clientStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assume.assumeTrue("Client started. " + "Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT + " " + TIME_UNIT, clientStarted);
+        } catch (final Exception exception) {
+            Assume.assumeNoException(exception);
+        }
+    }
+
+    @Override
+    final void afterCustom(final RosExecutor rosExecutor) {
+        try {
+            rosExecutor.stopNodeMain(this.fibonacciActionLibServer);
+        } catch (final Exception ignored) {
+        }
+        try {
+            rosExecutor.stopNodeMain(this.futureBasedClientNode);
+        } catch (final Exception ignored) {
+        }
+        this.futureBasedClientNode = null;
+        this.fibonacciActionLibServer = null;
+    }
+
+    private Map<?, ?> getTrackedGoalsMap() {
+        try {
+            final Field actionServerField = FibonacciActionLibServer.class.getDeclaredField("actionServer");
+            actionServerField.setAccessible(true);
+            final Object actionServer = actionServerField.get(this.fibonacciActionLibServer);
+
+            final Field trackedGoalsField = ActionServer.class.getDeclaredField("goalIdToGoalStatusMap");
+            trackedGoalsField.setAccessible(true);
+            return (Map<?, ?>) trackedGoalsField.get(actionServer);
+        } catch (final Exception exception) {
+            throw new AssertionError(exception);
+        }
+    }
+
+    private void waitUntil(final CheckedCondition condition, final long timeoutMillis) throws Exception {
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        while (!condition.evaluate() && System.nanoTime() < deadline) {
+            Thread.sleep(50);
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedCondition {
+        boolean evaluate() throws Exception;
+    }
+}

--- a/src/test/java/com/github/rosjava_actionlib/ActionServerTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionServerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
 import actionlib_msgs.GoalStatus;

--- a/src/test/java/com/github/rosjava_actionlib/BaseTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/BaseTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
 import eu.test.utils.RosExecutor;

--- a/src/test/java/com/github/rosjava_actionlib/ClientStateMachineTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ClientStateMachineTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Ekumen www.ekumenlabs.com
+ * Copyright 2023 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
 import org.junit.Before;

--- a/src/test/java/com/github/rosjava_actionlib/FibonacciActionLibServer.java
+++ b/src/test/java/com/github/rosjava_actionlib/FibonacciActionLibServer.java
@@ -1,7 +1,6 @@
-package com.github.rosjava_actionlib;
-
 /**
  * Copyright 2015 Ekumen www.ekumenlabs.com
+ * Copyright 2023 Spyros Koukas
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +14,7 @@ package com.github.rosjava_actionlib;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.github.rosjava_actionlib;
 
 
 import actionlib_msgs.GoalID;
@@ -29,7 +29,6 @@ import org.ros.node.AbstractNodeMain;
 import org.ros.node.ConnectedNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import std_msgs.Bool;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
@@ -37,7 +36,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Ernesto Corbellini ecorbellini@ekumenlabs.com
@@ -48,11 +46,29 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 final class FibonacciActionLibServer extends AbstractNodeMain implements ActionServerListener<FibonacciActionGoal> {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final long DEFAULT_TERMINAL_STATUS_RETENTION_MILLIS = 5000;
     private ActionServer<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> actionServer = null;
     private volatile FibonacciActionGoal currentGoal = null;
     private final FibonacciCalculator fibonacciCalculator = new FibonacciCalculator();
     private final CountDownLatch startCountDownLatch = new CountDownLatch(1);
     private final Set<String> cancelledGoalIds = new ConcurrentSkipListSet<>();
+    private final boolean setExplicitResultStatus;
+    private final long terminalStatusRetention;
+    private final TimeUnit terminalStatusRetentionTimeUnit;
+
+    FibonacciActionLibServer() {
+        this(true);
+    }
+
+    FibonacciActionLibServer(final boolean setExplicitResultStatus) {
+        this(setExplicitResultStatus, DEFAULT_TERMINAL_STATUS_RETENTION_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    FibonacciActionLibServer(final boolean setExplicitResultStatus, final long terminalStatusRetention, final TimeUnit terminalStatusRetentionTimeUnit) {
+        this.setExplicitResultStatus = setExplicitResultStatus;
+        this.terminalStatusRetention = terminalStatusRetention;
+        this.terminalStatusRetentionTimeUnit = terminalStatusRetentionTimeUnit;
+    }
 
     @Override
     public final GraphName getDefaultNodeName() {
@@ -81,7 +97,8 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
     public final void onStart(final ConnectedNode node) {
 
         this.actionServer = new ActionServer<>(node, this, FibonacciGraphNames.ACTION_GRAPH_NAME, FibonacciActionGoal._TYPE,
-                FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE);
+                FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE,
+                this.terminalStatusRetention, this.terminalStatusRetentionTimeUnit);
 
         this.startCountDownLatch.countDown();
     }
@@ -133,12 +150,14 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
             if (this.shouldCancelGoal(goal)) {
                 this.cancelledGoalIds.remove(goal.getGoalId().getId());
             } else {
-                result.getStatus().setStatus(GoalStatus.SUCCEEDED);
+                if (this.setExplicitResultStatus) {
+                    result.getStatus().setStatus(GoalStatus.SUCCEEDED);
+                }
                 this.actionServer.setSucceed(goal.getGoalId().getId());
             }
             LOGGER.trace("About to publish result for goalId:[" + result.getStatus().getGoalId().getId() + "] status:[" + result.getStatus().getStatus() + "]");
             this.actionServer.sendResult(result);
-            this.currentGoal=null;
+            this.currentGoal = null;
             return Optional.empty();
         } else {
             LOGGER.trace("We already have a goal! New goal reject.");

--- a/src/test/java/com/github/rosjava_actionlib/FibonacciCalculator.java
+++ b/src/test/java/com/github/rosjava_actionlib/FibonacciCalculator.java
@@ -1,12 +1,25 @@
+/**
+ * Copyright 2019 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Runnables;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 

--- a/src/test/java/com/github/rosjava_actionlib/FibonacciFutureBasedClientNodeTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/FibonacciFutureBasedClientNodeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Spyros Koukas
+ * Copyright 2023 Spyros Koukas
  *
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,8 @@
 
 package com.github.rosjava_actionlib;
 
+import actionlib_msgs.GoalID;
+import actionlib_msgs.GoalStatus;
 import actionlib_tutorials.FibonacciActionFeedback;
 import actionlib_tutorials.FibonacciActionGoal;
 import actionlib_tutorials.FibonacciActionResult;
@@ -26,18 +28,24 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.ros.internal.message.Message;
+import org.ros.node.ConnectedNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Focus on {@link FutureBasedClientNode} status changes
  * Demonstrate future usage
+ * @author Spyros Koukas
  */
 public class FibonacciFutureBasedClientNodeTest extends BaseTest {
 
@@ -120,6 +128,42 @@ public class FibonacciFutureBasedClientNodeTest extends BaseTest {
     }
 
     @Test
+    public final void testTerminalStatusIsPublishedAfterResult() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        final CountDownLatch terminalStatusReceived = new CountDownLatch(1);
+        final AtomicReference<Byte> terminalStatus = new AtomicReference<>();
+
+        this.futureBasedClientNode.getActionClient().addActionClientStatusListener(statusArray -> statusArray.getStatusList().stream()
+                .filter(goalStatus -> goalStatus != null)
+                .map(goalStatus -> goalStatus.getStatus())
+                .filter(ActionServer::isTerminalStatus)
+                .findFirst()
+                .ifPresent(status -> {
+                    terminalStatus.compareAndSet(null, status);
+                    terminalStatusReceived.countDown();
+                }));
+
+        try {
+            final boolean serverStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT, TIME_UNIT);
+            Assert.assertTrue("Was not connected. Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT, serverStarted);
+
+            final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> resultFuture =
+                    this.futureBasedClientNode.invoke(TestInputs.TEST_INPUT);
+
+            final FibonacciActionResult result = resultFuture.get(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertNotNull("Null Result", result);
+            Assert.assertTrue("Result was wrong", Arrays.equals(result.getResult().getSequence(), TestInputs.TEST_CORRECT_OUTPUT));
+
+            final boolean statusReceived =
+                    terminalStatusReceived.await(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertTrue("Expected a terminal /status publication after the result", statusReceived);
+            Assert.assertEquals("Expected SUCCEEDED terminal status", Byte.valueOf(GoalStatus.SUCCEEDED), terminalStatus.get());
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
+    }
+
+    @Test
     public void testResultListener() {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         final CountDownLatch resultReceived = new CountDownLatch(1);
@@ -141,6 +185,27 @@ public class FibonacciFutureBasedClientNodeTest extends BaseTest {
 
     }
 
+    @Test
+    public final void testCancelForDifferentGoalDoesNotChangeCurrentGoalState() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            final boolean serverStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT, TIME_UNIT);
+            Assert.assertTrue("Was not connected. Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT, serverStarted);
+
+            final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> resultFuture =
+                    this.futureBasedClientNode.invoke(TestInputs.HUGE_INPUT);
+
+            final GoalID unrelatedGoalId = this.futureBasedClientNode.getActionClient().newGoalMessage().getGoalId();
+            unrelatedGoalId.setId("unrelated-goal-id");
+            final boolean cancelSent = this.futureBasedClientNode.getActionClient().sendCancelInternal(unrelatedGoalId);
+
+            Assert.assertTrue("Cancelling a different GoalID should still publish the cancel request", cancelSent);
+            Assert.assertNotEquals("Cancelling a different GoalID should not change the current goal state",
+                    ClientState.WAITING_FOR_CANCEL_ACK, resultFuture.getCurrentState());
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
+    }
 
     @Test
     public void testCancel() {
@@ -169,6 +234,23 @@ public class FibonacciFutureBasedClientNodeTest extends BaseTest {
             Assert.fail(ExceptionUtils.getStackTrace(exception));
         }
 
+    }
+
+    @Test
+    public final void testResultForDifferentGoalIsIgnoredBeforeAnyGoalIsSent() {
+        try {
+            final ActionClient<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> actionClient =
+                    this.futureBasedClientNode.getActionClient();
+            final ConnectedNode connectedNode = (ConnectedNode) getDeclaredFieldValue(ActionClient.class, actionClient, "connectedNode");
+            final FibonacciActionResult resultMessage = connectedNode.getDefaultMessageFactory().newFromType(FibonacciActionResult._TYPE);
+            resultMessage.getStatus().getGoalId().setId("unrelated-goal-id");
+
+            final Method gotResult = ActionClient.class.getDeclaredMethod("gotResult", Message.class);
+            gotResult.setAccessible(true);
+            gotResult.invoke(actionClient, resultMessage);
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
     }
 
 
@@ -207,6 +289,16 @@ public class FibonacciFutureBasedClientNodeTest extends BaseTest {
         }
         this.futureBasedClientNode = null;
         this.fibonacciActionLibServer = null;
+    }
+
+    private static Object getDeclaredFieldValue(final Class<?> ownerClass, final Object target, final String fieldName) {
+        try {
+            final Field field = ownerClass.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(target);
+        } catch (final Exception exception) {
+            throw new AssertionError(exception);
+        }
     }
 
 }

--- a/src/test/java/com/github/rosjava_actionlib/FibonacciGraphNames.java
+++ b/src/test/java/com/github/rosjava_actionlib/FibonacciGraphNames.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2024 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
 final class FibonacciGraphNames {

--- a/src/test/java/com/github/rosjava_actionlib/TestInputs.java
+++ b/src/test/java/com/github/rosjava_actionlib/TestInputs.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2024 Spyros Koukas
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rosjava_actionlib;
 
 interface TestInputs {

--- a/src/test/java/com/github/rosjava_actionlib/TurtleSimActionLibClient.java
+++ b/src/test/java/com/github/rosjava_actionlib/TurtleSimActionLibClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Spyros Koukas
+ * Copyright 2020 Spyros Koukas
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/rosjava_actionlib/TurtleSimActionLibClientTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/TurtleSimActionLibClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Spyros Koukas
+ * Copyright 2020 Spyros Koukas
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/rosjava_actionlib/WaitMethodsClientServerTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/WaitMethodsClientServerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Spyros Koukas
+ * Copyright 2023 Spyros Koukas
  *
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,11 +20,13 @@ package com.github.rosjava_actionlib;
 import actionlib_tutorials.FibonacciActionFeedback;
 import actionlib_tutorials.FibonacciActionGoal;
 import actionlib_tutorials.FibonacciActionResult;
-import com.google.common.base.Stopwatch;
 import eu.test.utils.RosExecutor;
 import eu.test.utils.TestProperties;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.ros.RosCore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
- retain terminal `/status` entries for 5 seconds
- publish `/result` from tracked server state
- report whether cancel was sent
- ignore unrelated goal traffic safely
- keep completed futures terminal and clean up abandoned listeners
- add regression tests