### PR TITLE
Implement early cancel handling in ActionServer with coverage

### DIFF
--- a/src/main/java/com/github/rosjava_actionlib/ActionServer.java
+++ b/src/main/java/com/github/rosjava_actionlib/ActionServer.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.ros.internal.message.Message;
 import org.ros.message.MessageFactory;
+import org.ros.message.Time;
 import org.ros.node.ConnectedNode;
 import org.ros.node.topic.Publisher;
 import org.ros.node.topic.Subscriber;
@@ -35,6 +36,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Class to encapsulate the actionlib server's communication and goal management.
@@ -79,6 +81,7 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
     private final long terminalStatusRetentionNanos;
     private final Timer statusTick = new Timer();
     private final ConcurrentHashMap<String, ServerGoal<T_ACTION_GOAL>> goalIdToGoalStatusMap = new ConcurrentHashMap<>();
+    private volatile Time lastCancelStamp = new Time();
 
     //Non Final
     private Subscriber<T_ACTION_GOAL> goalSubscriber = null;
@@ -373,9 +376,35 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
         if (goal != null) {
             final GoalID goalId = getGoalId(goal);
             final String goalIdString = goalId.getId();
+            final AtomicBoolean goalAlreadyTracked = new AtomicBoolean(false);
+            final ServerGoal<T_ACTION_GOAL> trackedGoal = this.goalIdToGoalStatusMap.compute(goalIdString, (id, existingGoal) -> {
+                if (existingGoal != null) {
+                    goalAlreadyTracked.set(true);
+                    if (existingGoal.goal == null) {
+                        copyGoalId(goalId, existingGoal.goalId);
+                    }
+                    return existingGoal;
+                }
+                return new ServerGoal<>(goal, ActionServer.this.copyGoalId(goalId));
+            });
+            final byte trackedState = trackedGoal.stateMachine.getState();
+            final boolean matchedPendingCancelPlaceholder =
+                    goalAlreadyTracked.get() && trackedGoal.goal == null && trackedState == GoalStatus.PENDING;
 
-            // start tracking this newly received goal
-            this.goalIdToGoalStatusMap.put(goalIdString, new ServerGoal<>(goal, goalId));
+            if (trackedState == GoalStatus.RECALLING || matchedPendingCancelPlaceholder) {
+                trackedGoal.terminalStatusRetentionDeadlineNanos = TERMINAL_STATUS_RETENTION_NOT_SCHEDULED_NANOS;
+                this.recallTrackedGoal(goalIdString);
+                return;
+            }
+
+            if (goalAlreadyTracked.get()) {
+                return;
+            }
+
+            if (this.isGoalCancelledByTimestamp(goalId)) {
+                this.recallTrackedGoal(goalIdString);
+                return;
+            }
 
             //this#actionServerListener is guaranteed to never be null, this call is for information purposes only
             this.actionServerListener.goalReceived(goal);
@@ -412,6 +441,26 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
      */
     public final void gotCancel(final GoalID goalID) {
         if (goalID != null) {
+            if (goalID.getStamp() != null && goalID.getStamp().compareTo(this.lastCancelStamp) > 0) {
+                this.lastCancelStamp = new Time(goalID.getStamp());
+            }
+            boolean exactGoalIdMatched = false;
+            for (final Map.Entry<String, ServerGoal<T_ACTION_GOAL>> entry : this.goalIdToGoalStatusMap.entrySet()) {
+                final String trackedGoalId = entry.getKey();
+                final ServerGoal<T_ACTION_GOAL> trackedGoal = entry.getValue();
+                if (this.matchesCancelRequest(goalID, trackedGoal.goalId)) {
+                    exactGoalIdMatched = exactGoalIdMatched || trackedGoalId.equals(goalID.getId());
+                    this.requestCancel(trackedGoalId);
+                }
+            }
+            if (StringUtils.isNotBlank(goalID.getId()) && !exactGoalIdMatched) {
+                final ServerGoal<T_ACTION_GOAL> pendingCancelledGoal = this.goalIdToGoalStatusMap.compute(goalID.getId(),
+                        (id, existingGoal) -> existingGoal == null ? new ServerGoal<>(null, ActionServer.this.copyGoalId(goalID)) : existingGoal);
+                if (pendingCancelledGoal != null) {
+                    copyGoalId(goalID, pendingCancelledGoal.goalId);
+                    this.requestCancel(goalID.getId());
+                }
+            }
             this.actionServerListener.cancelReceived(goalID);
         }
     }
@@ -433,7 +482,7 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
                 final String goalId = entry.getKey();
                 final ServerGoal<T_ACTION_GOAL> serverGoal = entry.getValue();
                 final byte goalState = serverGoal.stateMachine.getState();
-                if (isTerminalStatus(goalState)) {
+                if (shouldExpireStatusEntry(serverGoal, goalState)) {
                     final long retentionDeadlineNanos = serverGoal.terminalStatusRetentionDeadlineNanos;
                     if (retentionDeadlineNanos == TERMINAL_STATUS_RETENTION_NOT_SCHEDULED_NANOS) {
                         serverGoal.terminalStatusRetentionDeadlineNanos = nowNanos + this.terminalStatusRetentionNanos;
@@ -494,14 +543,8 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
      * @see actionlib_msgs.GoalStatus
      */
     public final byte getGoalStatus(final String goalId) {
-        final byte result;
-
-        if (this.goalIdToGoalStatusMap.containsKey(goalId)) {
-            result = this.goalIdToGoalStatusMap.get(goalId).stateMachine.getState();
-        } else {
-            result = -100;
-        }
-        return result;
+        final ServerGoal<T_ACTION_GOAL> trackedGoal = this.goalIdToGoalStatusMap.get(goalId);
+        return trackedGoal == null ? -100 : trackedGoal.stateMachine.getState();
     }
 
     /**
@@ -568,6 +611,97 @@ public final class ActionServer<T_ACTION_GOAL extends Message, T_ACTION_FEEDBACK
             value.stateMachine.transition(event);
             return value;
         });
+    }
+
+    static final boolean isCancelRequestedStatus(final byte status) {
+        return status == GoalStatus.PREEMPTING || status == GoalStatus.RECALLING;
+    }
+
+    static final boolean isCancelledStatus(final byte status) {
+        return status == GoalStatus.PREEMPTED || status == GoalStatus.RECALLED;
+    }
+
+    private static final boolean shouldExpireStatusEntry(final ServerGoal<?> serverGoal, final byte status) {
+        return isTerminalStatus(status) || isUnmatchedCancelPlaceholder(serverGoal, status);
+    }
+
+    private static final boolean isUnmatchedCancelPlaceholder(final ServerGoal<?> serverGoal, final byte status) {
+        return serverGoal != null && serverGoal.goal == null && status == GoalStatus.RECALLING;
+    }
+
+    private final GoalID copyGoalId(final GoalID source) {
+        final GoalID copy = this.messageFactory.newFromType(GoalID._TYPE);
+        copyGoalId(source, copy);
+        return copy;
+    }
+
+    private static final void copyGoalId(final GoalID source, final GoalID target) {
+        if (source == null || target == null) {
+            return;
+        }
+        target.setId(source.getId());
+        target.setStamp(source.getStamp() == null ? new Time() : new Time(source.getStamp()));
+    }
+
+    private final boolean isGoalCancelledByTimestamp(final GoalID goalId) {
+        return goalId != null
+                && goalId.getStamp() != null
+                && !goalId.getStamp().isZero()
+                && goalId.getStamp().compareTo(this.lastCancelStamp) <= 0;
+    }
+
+    private static final boolean isCancelAllRequest(final GoalID cancelGoalId) {
+        return cancelGoalId != null
+                && StringUtils.isBlank(cancelGoalId.getId())
+                && cancelGoalId.getStamp() != null
+                && cancelGoalId.getStamp().isZero();
+    }
+
+    private final boolean matchesCancelRequest(final GoalID cancelGoalId, final GoalID trackedGoalId) {
+        if (cancelGoalId == null || trackedGoalId == null) {
+            return false;
+        }
+        if (isCancelAllRequest(cancelGoalId)) {
+            return true;
+        }
+        if (StringUtils.isNotBlank(cancelGoalId.getId()) && cancelGoalId.getId().equals(trackedGoalId.getId())) {
+            return true;
+        }
+        return cancelGoalId.getStamp() != null
+                && !cancelGoalId.getStamp().isZero()
+                && trackedGoalId.getStamp() != null
+                && trackedGoalId.getStamp().compareTo(cancelGoalId.getStamp()) <= 0;
+    }
+
+    private final void requestCancel(final String goalIdString) {
+        final ServerGoal<T_ACTION_GOAL> trackedGoal = this.goalIdToGoalStatusMap.get(goalIdString);
+        if (trackedGoal == null) {
+            return;
+        }
+        final byte currentState = trackedGoal.stateMachine.getState();
+        if (currentState == GoalStatus.PENDING || currentState == GoalStatus.ACTIVE) {
+            this.setCancelRequested(goalIdString);
+        }
+    }
+
+    private final void recallTrackedGoal(final String goalIdString) {
+        this.requestCancel(goalIdString);
+        this.setCancel(goalIdString);
+        this.publishTrackedResult(goalIdString);
+    }
+
+    private final void publishTrackedResult(final String goalIdString) {
+        final ServerGoal<T_ACTION_GOAL> trackedGoal = this.goalIdToGoalStatusMap.get(goalIdString);
+        if (trackedGoal == null) {
+            return;
+        }
+        final T_ACTION_RESULT resultMessage = this.newResultMessage();
+        final GoalStatus resultGoalStatus = this.getResultGoalStatus(resultMessage);
+        if (resultGoalStatus != null && resultGoalStatus.getGoalId() != null) {
+            copyGoalId(trackedGoal.goalId, resultGoalStatus.getGoalId());
+            resultGoalStatus.setStatus(trackedGoal.stateMachine.getState());
+        }
+        this.sendResult(resultMessage);
     }
 
     /**

--- a/src/test/java/com/github/rosjava_actionlib/ActionLibClientFeedbackListenerNode.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionLibClientFeedbackListenerNode.java
@@ -34,21 +34,22 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 
-class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements ActionClientResultListener<FibonacciActionResult> {
+final class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements ActionClientResultListener<FibonacciActionResult> {
     private final GoalStatusToString goalStatusToString = new GoalStatusToString();
+    private static final int MAX_PRINT_SEQUENCE_ELEMENTS = 100;
 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final CountDownLatch connectCountDownLatch = new CountDownLatch(1);
 
-    private ActionClient actionClient = null;
+    private ActionClient<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> actionClient = null;
 
     private Optional<FibonacciActionResult> result = Optional.empty();
     private CountDownLatch resultCountdownLatch = new CountDownLatch(1);
 
     @Override
-    public GraphName getDefaultNodeName() {
+    public final GraphName getDefaultNodeName() {
         return GraphName.of(FibonacciGraphNames.CLIENT_NODE_GRAPH_NAME);
     }
 
@@ -102,7 +103,7 @@ class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements Ac
         return this.resultCountdownLatch;
     }
 
-    public Optional<FibonacciActionResult> getFibonacciActionResultOptional() {
+    public final Optional<FibonacciActionResult> getFibonacciActionResultOptional() {
         return this.result;
     }
 
@@ -118,18 +119,33 @@ class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements Ac
     public final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> getFibonnaciCanceledFuture(final int order) {
 
 
-        final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> resulFuture = this.submitRequest(order);
+        final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> resultFuture = this.submitRequest(order);
         LOGGER.trace("Canceling");
-        resulFuture.cancel(true);
+        resultFuture.cancel(true);
         LOGGER.trace("Cancel Request sent");
-        return resulFuture;
+        return resultFuture;
 
 
     }
 
+    public final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> getFibonnaciEarlyCanceledFuture(final int order) {
+
+        final FibonacciActionGoal goalMessage = (FibonacciActionGoal) this.actionClient.newGoalMessage();
+        goalMessage.getGoal().setOrder(order);
+        final String goalId = this.getDefaultNodeName() + "-early-cancel-" + System.nanoTime();
+        goalMessage.getGoalId().setId(goalId);
+        this.result = Optional.empty();
+        this.resultCountdownLatch = new CountDownLatch(1);
+
+        LOGGER.trace("Sending early cancel for goal ID: {}", goalId);
+        this.actionClient.sendCancel(goalMessage.getGoalId());
+        LOGGER.trace("Sending goal after cancel for goal ID: {}", goalId);
+        return this.actionClient.sendGoal(goalMessage, goalId);
+    }
+
     @Override
-    public void onStart(final ConnectedNode connectedNode) {
-        this.actionClient = new ActionClient<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult>(connectedNode, FibonacciGraphNames.ACTION_GRAPH_NAME, FibonacciActionGoal._TYPE, FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE);
+    public final void onStart(final ConnectedNode connectedNode) {
+        this.actionClient = new ActionClient<>(connectedNode, FibonacciGraphNames.ACTION_GRAPH_NAME, FibonacciActionGoal._TYPE, FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE);
         this.actionClient.addActionClientResultListener(this);
         this.connectCountDownLatch.countDown();
     }
@@ -138,7 +154,7 @@ class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements Ac
      *
      */
     @Override
-    public void resultReceived(final FibonacciActionResult actionResult) {
+    public final void resultReceived(final FibonacciActionResult actionResult) {
         this.result = Optional.ofNullable(actionResult);
 
         this.resultCountdownLatch.countDown();
@@ -148,9 +164,11 @@ class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements Ac
 
             final StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("Got Fibonacci result sequence: ");
-            for (int i = 0; i < sequence.length; i++) {
-                stringBuilder.append(Integer.toString(sequence[i]));
-                stringBuilder.append("");
+            for (int i = 0; i < Math.min(sequence.length, MAX_PRINT_SEQUENCE_ELEMENTS); i++) {
+                stringBuilder.append(sequence[i]);
+            }
+            if (sequence.length > MAX_PRINT_SEQUENCE_ELEMENTS) {
+                stringBuilder.append("... showing first ").append(MAX_PRINT_SEQUENCE_ELEMENTS).append(" elements");
             }
 
             LOGGER.trace(stringBuilder.toString());
@@ -158,15 +176,17 @@ class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements Ac
     }
 
     //    @Override
-    public void feedbackReceived(final FibonacciActionFeedback message) {
+    public final void feedbackReceived(final FibonacciActionFeedback message) {
         if (LOGGER.isTraceEnabled()) {
             final FibonacciFeedback result = message.getFeedback();
             final int[] sequence = result.getSequence();
             final StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("Got Fibonacci feedback sequence: ");
-            for (int i = 0; i < sequence.length; i++) {
+            for (int i = 0; i < Math.min(sequence.length, MAX_PRINT_SEQUENCE_ELEMENTS); i++) {
                 stringBuilder.append(sequence[i]);
-                stringBuilder.append("");
+            }
+            if (sequence.length > MAX_PRINT_SEQUENCE_ELEMENTS) {
+                stringBuilder.append("... showing first ").append(MAX_PRINT_SEQUENCE_ELEMENTS).append(" elements");
             }
             LOGGER.trace(stringBuilder.toString());
         }
@@ -178,7 +198,7 @@ class ActionLibClientFeedbackListenerNode extends AbstractNodeMain implements Ac
      * @param status The status message received from the server.
      */
 //    @Override
-    public void statusReceived(final GoalStatusArray status) {
+    public final void statusReceived(final GoalStatusArray status) {
         if (LOGGER.isTraceEnabled()) {
             final StringJoiner stringJoiner = new StringJoiner(",", "Status:{", "}");
             for (final GoalStatus goalStatus : status.getStatusList()) {

--- a/src/test/java/com/github/rosjava_actionlib/ActionServerTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ActionServerTest.java
@@ -15,11 +15,33 @@
  */
 package com.github.rosjava_actionlib;
 
+import actionlib_msgs.GoalID;
 import actionlib_msgs.GoalStatus;
+import actionlib_msgs.GoalStatusArray;
+import actionlib_tutorials.FibonacciActionFeedback;
+import actionlib_tutorials.FibonacciActionGoal;
+import actionlib_tutorials.FibonacciActionResult;
 import org.junit.Assert;
 import org.junit.Test;
+import org.ros.internal.message.DefaultMessageFactory;
+import org.ros.internal.message.Message;
+import org.ros.internal.message.definition.MessageDefinitionReflectionProvider;
+import org.ros.message.MessageFactory;
+import org.ros.message.Time;
+import org.ros.namespace.GraphName;
+import org.ros.node.ConnectedNode;
+import org.ros.node.topic.Publisher;
+import org.ros.node.topic.Subscriber;
 
-public class ActionServerTest {
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class ActionServerTest {
+    private static final String ACTION_NAME = "/action_server_test";
 
     @Test
     public final void terminalStatusesAreMarkedForEviction() {
@@ -37,5 +59,378 @@ public class ActionServerTest {
         Assert.assertFalse(ActionServer.isTerminalStatus(GoalStatus.RECALLING));
         Assert.assertFalse(ActionServer.isTerminalStatus(GoalStatus.PREEMPTING));
         Assert.assertFalse(ActionServer.isTerminalStatus(GoalStatus.LOST));
+    }
+
+    @Test
+    public final void acceptedGoalBecomesActiveAndInvokesUserCallbacks() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            final FibonacciActionGoal goal = harness.newGoal("accepted-goal", new Time(20, 0), 5);
+
+            harness.actionServer.gotGoal(goal);
+
+            Assert.assertEquals(1, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(1, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(GoalStatus.ACTIVE, harness.actionServer.getGoalStatus(goal.getGoalId().getId()));
+            Assert.assertTrue(harness.resultPublisher.publishedMessages.isEmpty());
+        }
+    }
+
+    @Test
+    public final void cancelAfterAcceptanceTransitionsGoalToPreempting() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            final FibonacciActionGoal goal = harness.newGoal("preempt-goal", new Time(30, 0), 5);
+
+            harness.actionServer.gotGoal(goal);
+            harness.actionServer.gotCancel(harness.newGoalId(goal.getGoalId().getId(), goal.getGoalId().getStamp()));
+
+            Assert.assertEquals(1, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(1, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(1, harness.listener.cancelReceivedCount.get());
+            Assert.assertEquals(GoalStatus.PREEMPTING, harness.actionServer.getGoalStatus(goal.getGoalId().getId()));
+            Assert.assertTrue(harness.resultPublisher.publishedMessages.isEmpty());
+        }
+    }
+
+    @Test
+    public final void exactIdCancelBeforeGoalRecallsWithoutUserCallbacks() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            final String goalId = "recalled-goal";
+            final FibonacciActionGoal goal = harness.newGoal(goalId, new Time(40, 0), 5);
+
+            harness.actionServer.gotCancel(harness.newGoalId(goalId, new Time()));
+            harness.actionServer.gotGoal(goal);
+
+            Assert.assertEquals(0, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(0, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(1, harness.listener.cancelReceivedCount.get());
+            Assert.assertEquals(GoalStatus.RECALLED, harness.actionServer.getGoalStatus(goalId));
+
+            final FibonacciActionResult result = harness.resultPublisher.getLastPublishedMessage();
+            Assert.assertNotNull(result);
+            Assert.assertEquals(GoalStatus.RECALLED, result.getStatus().getStatus());
+            Assert.assertEquals(goalId, result.getStatus().getGoalId().getId());
+            Assert.assertEquals(goal.getGoalId().getStamp(), result.getStatus().getGoalId().getStamp());
+        }
+    }
+
+    @Test
+    public final void timestampCancelBeforeGoalRecallsMatchingGoalWithoutUserCallbacks() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            final Time cancelStamp = new Time(50, 0);
+            final FibonacciActionGoal goal = harness.newGoal("timestamp-goal", new Time(49, 0), 5);
+
+            harness.actionServer.gotCancel(harness.newGoalId("", cancelStamp));
+            harness.actionServer.gotGoal(goal);
+
+            Assert.assertEquals(0, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(0, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(GoalStatus.RECALLED, harness.actionServer.getGoalStatus(goal.getGoalId().getId()));
+
+            final FibonacciActionResult result = harness.resultPublisher.getLastPublishedMessage();
+            Assert.assertNotNull(result);
+            Assert.assertEquals(GoalStatus.RECALLED, result.getStatus().getStatus());
+        }
+    }
+
+    @Test
+    public final void timestampCancelDoesNotRecallNewerGoal() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            harness.actionServer.gotCancel(harness.newGoalId("", new Time(60, 0)));
+            final FibonacciActionGoal goal = harness.newGoal("newer-goal", new Time(61, 0), 5);
+
+            harness.actionServer.gotGoal(goal);
+
+            Assert.assertEquals(1, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(1, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(GoalStatus.ACTIVE, harness.actionServer.getGoalStatus(goal.getGoalId().getId()));
+            Assert.assertTrue(harness.resultPublisher.publishedMessages.isEmpty());
+        }
+    }
+
+    @Test
+    public final void cancelAllAffectsTrackedGoalsButNotFutureGoals() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            final FibonacciActionGoal firstGoal = harness.newGoal("tracked-goal-1", new Time(80, 0), 5);
+            final FibonacciActionGoal secondGoal = harness.newGoal("tracked-goal-2", new Time(81, 0), 5);
+
+            harness.actionServer.gotGoal(firstGoal);
+            harness.actionServer.gotGoal(secondGoal);
+            harness.actionServer.gotCancel(harness.newGoalId("", new Time()));
+
+            Assert.assertEquals(GoalStatus.PREEMPTING, harness.actionServer.getGoalStatus(firstGoal.getGoalId().getId()));
+            Assert.assertEquals(GoalStatus.PREEMPTING, harness.actionServer.getGoalStatus(secondGoal.getGoalId().getId()));
+
+            final FibonacciActionGoal futureGoal = harness.newGoal("future-goal", new Time(82, 0), 5);
+            harness.actionServer.gotGoal(futureGoal);
+
+            Assert.assertEquals(GoalStatus.ACTIVE, harness.actionServer.getGoalStatus(futureGoal.getGoalId().getId()));
+            Assert.assertEquals(3, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(3, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(1, harness.listener.cancelReceivedCount.get());
+            Assert.assertTrue(harness.resultPublisher.publishedMessages.isEmpty());
+        }
+    }
+
+    @Test
+    public final void unmatchedExactCancelPlaceholderExpiresWhenGoalNeverArrives() throws Exception {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE), 5, TimeUnit.MILLISECONDS)) {
+            final String goalId = "missing-goal";
+
+            harness.actionServer.gotCancel(harness.newGoalId(goalId, new Time()));
+            Assert.assertEquals(GoalStatus.RECALLING, harness.actionServer.getGoalStatus(goalId));
+
+            harness.actionServer.sendStatusTick();
+            Thread.sleep(20);
+            harness.actionServer.sendStatusTick();
+
+            Assert.assertEquals(-100, harness.actionServer.getGoalStatus(goalId));
+        }
+    }
+
+    @Test
+    public final void goalIsHandledNormallyAfterExpiredPlaceholderIsRemoved() throws Exception {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE), 5, TimeUnit.MILLISECONDS)) {
+            final String goalId = "late-goal";
+            final FibonacciActionGoal goal = harness.newGoal(goalId, new Time(70, 0), 5);
+
+            harness.actionServer.gotCancel(harness.newGoalId(goalId, new Time()));
+            harness.actionServer.sendStatusTick();
+            Thread.sleep(20);
+            harness.actionServer.sendStatusTick();
+
+            harness.actionServer.gotGoal(goal);
+
+            Assert.assertEquals(1, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(1, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(GoalStatus.ACTIVE, harness.actionServer.getGoalStatus(goalId));
+            Assert.assertTrue(harness.resultPublisher.publishedMessages.isEmpty());
+        }
+    }
+
+    @Test
+    public final void duplicateGoalIdIsIgnoredWithoutMutatingTrackedGoalMetadata() {
+        try (ActionServerHarness harness = new ActionServerHarness(Optional.of(Boolean.TRUE))) {
+            final String goalId = "duplicate-goal";
+            final Time originalStamp = new Time(90, 0);
+            final Time duplicateStamp = new Time(91, 0);
+            final FibonacciActionGoal firstGoal = harness.newGoal(goalId, originalStamp, 5);
+            final FibonacciActionGoal duplicateGoal = harness.newGoal(goalId, duplicateStamp, 8);
+
+            harness.actionServer.gotGoal(firstGoal);
+            harness.actionServer.sendStatusTick();
+            harness.actionServer.gotGoal(duplicateGoal);
+            harness.actionServer.sendStatusTick();
+
+            Assert.assertEquals(1, harness.listener.goalReceivedCount.get());
+            Assert.assertEquals(1, harness.listener.acceptGoalCount.get());
+            Assert.assertEquals(GoalStatus.ACTIVE, harness.actionServer.getGoalStatus(goalId));
+            Assert.assertTrue(harness.resultPublisher.publishedMessages.isEmpty());
+
+            final GoalStatusArray latestStatus = harness.statusPublisher.getLastPublishedMessage();
+            Assert.assertNotNull(latestStatus);
+            Assert.assertEquals(1, latestStatus.getStatusList().size());
+            final GoalStatus trackedStatus = latestStatus.getStatusList().get(0);
+            Assert.assertEquals(goalId, trackedStatus.getGoalId().getId());
+            Assert.assertEquals(originalStamp, trackedStatus.getGoalId().getStamp());
+        }
+    }
+
+    private static final class ActionServerHarness implements AutoCloseable {
+        private static final String ACTION_RESULT_TOPIC = ACTION_NAME + "/result";
+        private static final String ACTION_FEEDBACK_TOPIC = ACTION_NAME + "/feedback";
+        private static final String ACTION_STATUS_TOPIC = ACTION_NAME + "/status";
+        private static final String ACTION_GOAL_TOPIC = ACTION_NAME + "/goal";
+        private static final String ACTION_CANCEL_TOPIC = ACTION_NAME + "/cancel";
+
+        private final MessageFactory messageFactory =
+                new DefaultMessageFactory(new MessageDefinitionReflectionProvider());
+        private final CapturingPublisher<FibonacciActionResult> resultPublisher =
+                new CapturingPublisher<>(this.messageFactory, FibonacciActionResult._TYPE);
+        private final CapturingPublisher<FibonacciActionFeedback> feedbackPublisher =
+                new CapturingPublisher<>(this.messageFactory, FibonacciActionFeedback._TYPE);
+        private final CapturingPublisher<GoalStatusArray> statusPublisher =
+                new CapturingPublisher<>(this.messageFactory, GoalStatusArray._TYPE);
+        private final CapturingSubscriber<FibonacciActionGoal> goalSubscriber = new CapturingSubscriber<>();
+        private final CapturingSubscriber<GoalID> cancelSubscriber = new CapturingSubscriber<>();
+        private final RecordingListener listener;
+        private final ActionServer<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> actionServer;
+
+        private ActionServerHarness(final Optional<Boolean> acceptGoalResponse) {
+            this(acceptGoalResponse, 5000, TimeUnit.MILLISECONDS);
+        }
+
+        private ActionServerHarness(final Optional<Boolean> acceptGoalResponse,
+                                    final long terminalStatusRetention,
+                                    final TimeUnit terminalStatusRetentionTimeUnit) {
+            this.listener = new RecordingListener(acceptGoalResponse);
+            this.actionServer = new ActionServer<>(this.createConnectedNode(), this.listener, ACTION_NAME,
+                    FibonacciActionGoal._TYPE, FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE,
+                    terminalStatusRetention, terminalStatusRetentionTimeUnit);
+        }
+
+        private final FibonacciActionGoal newGoal(final String goalId, final Time stamp, final int order) {
+            final FibonacciActionGoal goal = this.messageFactory.newFromType(FibonacciActionGoal._TYPE);
+            goal.getGoalId().setId(goalId);
+            goal.getGoalId().setStamp(new Time(stamp));
+            goal.getGoal().setOrder(order);
+            return goal;
+        }
+
+        private final GoalID newGoalId(final String goalId, final Time stamp) {
+            final GoalID result = this.messageFactory.newFromType(GoalID._TYPE);
+            result.setId(goalId);
+            result.setStamp(new Time(stamp));
+            return result;
+        }
+
+        private final ConnectedNode createConnectedNode() {
+            return (ConnectedNode) Proxy.newProxyInstance(
+                    ConnectedNode.class.getClassLoader(),
+                    new Class[]{ConnectedNode.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "getDefaultMessageFactory" -> this.messageFactory;
+                        case "newPublisher" -> this.getPublisher((String) args[0]);
+                        case "newSubscriber" -> this.getSubscriber((String) args[0]);
+                        case "getName" -> GraphName.of("/action_server_test_node");
+                        case "resolveName" -> args[0] instanceof GraphName ? args[0] : GraphName.of((String) args[0]);
+                        case "shutdown", "removeListeners" -> null;
+                        default -> defaultValue(method.getReturnType());
+                    });
+        }
+
+        private final Object getPublisher(final String topicName) {
+            if (ACTION_RESULT_TOPIC.equals(topicName)) {
+                return this.resultPublisher.proxy;
+            }
+            if (ACTION_FEEDBACK_TOPIC.equals(topicName)) {
+                return this.feedbackPublisher.proxy;
+            }
+            if (ACTION_STATUS_TOPIC.equals(topicName)) {
+                return this.statusPublisher.proxy;
+            }
+            throw new IllegalArgumentException("Unexpected publisher topic:" + topicName);
+        }
+
+        private final Object getSubscriber(final String topicName) {
+            if (ACTION_GOAL_TOPIC.equals(topicName)) {
+                return this.goalSubscriber.proxy;
+            }
+            if (ACTION_CANCEL_TOPIC.equals(topicName)) {
+                return this.cancelSubscriber.proxy;
+            }
+            throw new IllegalArgumentException("Unexpected subscriber topic:" + topicName);
+        }
+
+        @Override
+        public final void close() {
+            this.actionServer.finish();
+        }
+    }
+
+    private static final class RecordingListener implements ActionServerListener<FibonacciActionGoal> {
+        private final AtomicInteger goalReceivedCount = new AtomicInteger();
+        private final AtomicInteger acceptGoalCount = new AtomicInteger();
+        private final AtomicInteger cancelReceivedCount = new AtomicInteger();
+        private final Optional<Boolean> acceptGoalResponse;
+
+        private RecordingListener(final Optional<Boolean> acceptGoalResponse) {
+            this.acceptGoalResponse = acceptGoalResponse;
+        }
+
+        @Override
+        public final void goalReceived(final FibonacciActionGoal goal) {
+            this.goalReceivedCount.incrementAndGet();
+        }
+
+        @Override
+        public final Optional<Boolean> acceptGoal(final FibonacciActionGoal goal) {
+            this.acceptGoalCount.incrementAndGet();
+            return this.acceptGoalResponse;
+        }
+
+        @Override
+        public final void cancelReceived(final GoalID id) {
+            this.cancelReceivedCount.incrementAndGet();
+        }
+    }
+
+    private static final class CapturingPublisher<T extends Message> {
+        private final List<T> publishedMessages = new CopyOnWriteArrayList<>();
+        private final Publisher<T> proxy;
+
+        @SuppressWarnings("unchecked")
+        private CapturingPublisher(final MessageFactory messageFactory, final String messageType) {
+            this.proxy = (Publisher<T>) Proxy.newProxyInstance(
+                    Publisher.class.getClassLoader(),
+                    new Class[]{Publisher.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "newMessage" -> messageFactory.newFromType(messageType);
+                        case "publish" -> {
+                            this.publishedMessages.add((T) args[0]);
+                            yield null;
+                        }
+                        case "setLatchMode", "shutdown", "addListener" -> null;
+                        case "getLatchMode", "hasSubscribers" -> Boolean.FALSE;
+                        case "getNumberOfSubscribers" -> 0;
+                        default -> defaultValue(method.getReturnType());
+                    });
+        }
+
+        private final T getLastPublishedMessage() {
+            if (this.publishedMessages.isEmpty()) {
+                return null;
+            }
+            return this.publishedMessages.get(this.publishedMessages.size() - 1);
+        }
+    }
+
+    private static final class CapturingSubscriber<T extends Message> {
+        private final Subscriber<T> proxy;
+
+        @SuppressWarnings("unchecked")
+        private CapturingSubscriber() {
+            this.proxy = (Subscriber<T>) Proxy.newProxyInstance(
+                    Subscriber.class.getClassLoader(),
+                    new Class[]{Subscriber.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "addMessageListener", "addSubscriberListener", "removeAllMessageListeners", "shutdown" -> null;
+                        case "removeMessageListener", "getLatchMode" -> Boolean.FALSE;
+                        default -> defaultValue(method.getReturnType());
+                    });
+        }
+    }
+
+    private static final Object defaultValue(final Class<?> returnType) {
+        if (returnType == null || Void.TYPE.equals(returnType)) {
+            return null;
+        }
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (Boolean.TYPE.equals(returnType)) {
+            return Boolean.FALSE;
+        }
+        if (Byte.TYPE.equals(returnType)) {
+            return (byte) 0;
+        }
+        if (Short.TYPE.equals(returnType)) {
+            return (short) 0;
+        }
+        if (Integer.TYPE.equals(returnType)) {
+            return 0;
+        }
+        if (Long.TYPE.equals(returnType)) {
+            return 0L;
+        }
+        if (Float.TYPE.equals(returnType)) {
+            return 0F;
+        }
+        if (Double.TYPE.equals(returnType)) {
+            return 0D;
+        }
+        if (Character.TYPE.equals(returnType)) {
+            return '\0';
+        }
+        throw new IllegalArgumentException("Unsupported primitive type:" + returnType);
     }
 }

--- a/src/test/java/com/github/rosjava_actionlib/AsyncGoalRunnerActionLibServer.java
+++ b/src/test/java/com/github/rosjava_actionlib/AsyncGoalRunnerActionLibServer.java
@@ -31,18 +31,15 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
  * @author Spyros Koukas
- * @deprecated does not work properly
  * A server that tries to calculate fibonnacis async
  */
-@Deprecated
-class AsyncGoalRunnerActionLibServer extends AbstractNodeMain implements ActionServerListener<FibonacciActionGoal> {
+final class AsyncGoalRunnerActionLibServer extends AbstractNodeMain implements ActionServerListener<FibonacciActionGoal> {
 
     private final FibonacciCalculator fibonacciCalculator = new FibonacciCalculator();
 
@@ -62,12 +59,12 @@ class AsyncGoalRunnerActionLibServer extends AbstractNodeMain implements ActionS
 
 
     @Override
-    public GraphName getDefaultNodeName() {
+    public final GraphName getDefaultNodeName() {
         return GraphName.of(FibonacciGraphNames.SERVER_NODE_GRAPH_NAME);
     }
 
     @Override
-    public void onStart(final ConnectedNode node) {
+    public final void onStart(final ConnectedNode node) {
 
 
         this.actionServer = new ActionServer<>(node, this, FibonacciGraphNames.ACTION_GRAPH_NAME, FibonacciActionGoal._TYPE, FibonacciActionFeedback._TYPE, FibonacciActionResult._TYPE);
@@ -95,23 +92,16 @@ class AsyncGoalRunnerActionLibServer extends AbstractNodeMain implements ActionS
      *
      */
     @Override
-    public void cancelReceived(final GoalID goalId) {
+    public final void cancelReceived(final GoalID goalId) {
         LOGGER.trace("Cancel received for ID:" + goalId);
+    }
 
-        if (goalId != null && goalId.getId() != null) {
-            final String id = goalId.getId();
-            final CompletableFuture<FibonacciActionResult> preexistingGoal = this.goals.get(id);
-            // If we don't have a goal, accept it. Otherwise, reject it.
-            if (preexistingGoal == null) {
-                LOGGER.trace("Goal not found");
+    private final boolean shouldCancelGoal(final String goalId) {
+        return ActionServer.isCancelRequestedStatus(this.actionServer.getGoalStatus(goalId));
+    }
 
-            } else {
-                preexistingGoal.cancel(true);
-                 this.goals.remove(id);
-            }
-            this.actionServer.setCancelRequested(id);
-        }
-
+    private final boolean isCancelledGoal(final String goalId) {
+        return ActionServer.isCancelledStatus(this.actionServer.getGoalStatus(goalId));
     }
 
     /**
@@ -139,22 +129,18 @@ class AsyncGoalRunnerActionLibServer extends AbstractNodeMain implements ActionS
 
                     final FibonacciActionResult result = actionServer.newResultMessage();
                     result.getStatus().setGoalId(goalIn.getGoalId());
-                    final Set<Byte> cancelingStatuses = Set.of(GoalStatus.PREEMPTING, GoalStatus.RECALLING);
-                    final Supplier<Boolean> shouldCancel = () -> cancelingStatuses.contains(this.actionServer.getGoalStatus(id));
-                    final Runnable onCancel = () -> {
-                        this.actionServer.setCancel(id);
-                        this.actionServer.sendStatusTick();
-                        LOGGER.info("Cancelled goal:" + id);
-                    };
+                    final Supplier<Boolean> shouldCancel = () -> this.shouldCancelGoal(id);
                     result.getResult().setSequence(fibonacciCalculator.fibonacciSequence(order, shouldCancel, Runnables::doNothing, feedbackProvider, order / 5));
                     LOGGER.trace("Sending result...");
 
-                    if (!cancelingStatuses.contains(this.actionServer.getGoalStatus(id))) {
+                    if (this.shouldCancelGoal(id)) {
+                        this.actionServer.setCancel(id);
+                    }
+                    if (!this.isCancelledGoal(id)) {
                         this.actionServer.setSucceed(id);
                         result.getStatus().setStatus(GoalStatus.SUCCEEDED);
                         LOGGER.trace("Succeeded goal:" + id);
                     } else {
-                        this.actionServer.setCancel(id);
                         result.getStatus().setStatus(GoalStatus.PREEMPTED);
                         LOGGER.trace("Canceled goal:" + id);
                     }

--- a/src/test/java/com/github/rosjava_actionlib/ClientServerFeedbackTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/ClientServerFeedbackTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.rosjava_actionlib;
 
+import actionlib_msgs.GoalStatus;
 import actionlib_tutorials.FibonacciActionFeedback;
 import actionlib_tutorials.FibonacciActionGoal;
 import actionlib_tutorials.FibonacciActionResult;
@@ -31,7 +32,7 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class ClientServerFeedbackTest {
+public final class ClientServerFeedbackTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final TestProperties testProperties = TestProperties.getFromDefaultFile();
@@ -46,7 +47,7 @@ public class ClientServerFeedbackTest {
     private final RosExecutor rosExecutor = new RosExecutor(ROS_HOST_IP);
 
     @Before
-    public void before() {
+    public final void before() {
         try {
             final boolean coreStartedOk ;
             if (!USE_EXTERNAL_ROS_MASTER) {
@@ -77,7 +78,7 @@ public class ClientServerFeedbackTest {
 
 
     @Test
-    public void testNormal() {
+    public final void testNormal() {
 
 
         try {
@@ -103,7 +104,7 @@ public class ClientServerFeedbackTest {
     }
 
     @Test
-    public void testCountDownLatch() {
+    public final void testCountDownLatch() {
 
 
         try {
@@ -133,15 +134,17 @@ public class ClientServerFeedbackTest {
     }
 
     @Test
-    public void testCancel() {
+    public final void testCancelPublishedBeforeGoalDoesNotSucceed() {
         try {
 
             LOGGER.trace("Starting Tasks");
 
-            final var resulFutureCancelled = this.actionLibClientFeedbackListenerNode.getFibonnaciCanceledFuture(TestInputs.HUGE_INPUT);
-            final FibonacciActionResult result = resulFutureCancelled.get(5, TimeUnit.SECONDS);
+            final var resultFutureCancelled = this.actionLibClientFeedbackListenerNode.getFibonnaciEarlyCanceledFuture(TestInputs.HUGE_INPUT);
+            final FibonacciActionResult result = resultFutureCancelled.get(5, TimeUnit.SECONDS);
             LOGGER.trace("Finished");
             Assert.assertNotNull("Result should not be null", result);
+            Assert.assertTrue("Result should be cancelled even if goal and cancel arrive on different topics in either order",
+                    result.getStatus().getStatus() == GoalStatus.RECALLED || result.getStatus().getStatus() == GoalStatus.PREEMPTED);
             Assert.assertFalse("Result should be incomplete", Arrays.equals(TestInputs.TEST_CORRECT_HUGE_INPUT_OUTPUT, result.getResult().getSequence()));
 
         } catch (final Exception e) {
@@ -151,7 +154,7 @@ public class ClientServerFeedbackTest {
     }
 
     @After
-    public void after() {
+    public final void after() {
         try {
             rosExecutor.stopNodeMain(this.asyncGoalRunnerActionLibServer);
         } catch (final Exception e2) {

--- a/src/test/java/com/github/rosjava_actionlib/FibonacciActionLibServer.java
+++ b/src/test/java/com/github/rosjava_actionlib/FibonacciActionLibServer.java
@@ -32,8 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -51,7 +49,6 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
     private volatile FibonacciActionGoal currentGoal = null;
     private final FibonacciCalculator fibonacciCalculator = new FibonacciCalculator();
     private final CountDownLatch startCountDownLatch = new CountDownLatch(1);
-    private final Set<String> cancelledGoalIds = new ConcurrentSkipListSet<>();
     private final boolean setExplicitResultStatus;
     private final long terminalStatusRetention;
     private final TimeUnit terminalStatusRetentionTimeUnit;
@@ -109,8 +106,12 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
 
     }
 
-    private final boolean shouldCancelGoal(final FibonacciActionGoal goal) {
-        return this.cancelledGoalIds.contains(goal.getGoalId().getId());
+    private final boolean shouldCancelGoal(final String goalId) {
+        return ActionServer.isCancelRequestedStatus(this.actionServer.getGoalStatus(goalId));
+    }
+
+    private final boolean isCancelledGoal(final String goalId) {
+        return ActionServer.isCancelledStatus(this.actionServer.getGoalStatus(goalId));
     }
 
     private static final void copyGoal(final GoalID from, final GoalID to) {
@@ -120,7 +121,6 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
 
     @Override
     public final void cancelReceived(final GoalID id) {
-        this.cancelledGoalIds.add(id.getId());
         LOGGER.trace("Cancel received for goal:" + id);
     }
 
@@ -129,8 +129,9 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
         // If we don't have a goal, accept it. Otherwise, reject it.
         if (this.currentGoal == null) {
             this.currentGoal = goal;
-            this.actionServer.setAccepted(this.currentGoal.getGoalId().getId());
-            LOGGER.trace("Goal accepted with goalId:[" + goal.getGoalId().getId() + "]");
+            final String goalId = this.currentGoal.getGoalId().getId();
+            this.actionServer.setAccepted(goalId);
+            LOGGER.trace("Goal accepted with goalId:[" + goalId + "]");
             final FibonacciActionFeedback feedback = this.actionServer.newFeedbackMessage();
             feedback.getStatus().setStatus(GoalStatus.ACTIVE);
             this.actionServer.sendFeedback(feedback);
@@ -143,17 +144,17 @@ final class FibonacciActionLibServer extends AbstractNodeMain implements ActionS
                 LOGGER.trace("Renaming Thread" + Thread.currentThread().getName());
                 Thread.currentThread().setName("GoalReceived " + Thread.currentThread().getName());
             }
-            final int[] output = fibonacciCalculator.fibonacciSequence(input, () -> this.shouldCancelGoal(goal), Runnables::doNothing);
+            final int[] output = fibonacciCalculator.fibonacciSequence(input, () -> this.shouldCancelGoal(goalId), Runnables::doNothing);
             result.getResult().setSequence(output);
 
-
-            if (this.shouldCancelGoal(goal)) {
-                this.cancelledGoalIds.remove(goal.getGoalId().getId());
-            } else {
+            if (this.shouldCancelGoal(goalId)) {
+                this.actionServer.setCancel(goalId);
+            }
+            if (!this.isCancelledGoal(goalId)) {
                 if (this.setExplicitResultStatus) {
                     result.getStatus().setStatus(GoalStatus.SUCCEEDED);
                 }
-                this.actionServer.setSucceed(goal.getGoalId().getId());
+                this.actionServer.setSucceed(goalId);
             }
             LOGGER.trace("About to publish result for goalId:[" + result.getStatus().getGoalId().getId() + "] status:[" + result.getStatus().getStatus() + "]");
             this.actionServer.sendResult(result);

--- a/src/test/java/com/github/rosjava_actionlib/FibonacciFutureBasedClientNodeTest.java
+++ b/src/test/java/com/github/rosjava_actionlib/FibonacciFutureBasedClientNodeTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 import org.ros.internal.message.Message;
+import org.ros.message.Time;
 import org.ros.node.ConnectedNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,6 +203,57 @@ public class FibonacciFutureBasedClientNodeTest extends BaseTest {
             Assert.assertTrue("Cancelling a different GoalID should still publish the cancel request", cancelSent);
             Assert.assertNotEquals("Cancelling a different GoalID should not change the current goal state",
                     ClientState.WAITING_FOR_CANCEL_ACK, resultFuture.getCurrentState());
+        } catch (final Exception exception) {
+            Assert.fail(ExceptionUtils.getStackTrace(exception));
+        }
+    }
+
+    @Test
+    public final void testCancelAllCancelsCurrentGoalButNotFutureGoal() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        final CountDownLatch goalTracked = new CountDownLatch(1);
+
+        this.futureBasedClientNode.getActionClient().addActionClientStatusListener(statusArray -> statusArray.getStatusList().stream()
+                .filter(goalStatus -> goalStatus != null)
+                .map(goalStatus -> goalStatus.getStatus())
+                .filter(status -> status == GoalStatus.PENDING
+                        || status == GoalStatus.ACTIVE
+                        || status == GoalStatus.PREEMPTING
+                        || status == GoalStatus.RECALLING)
+                .findFirst()
+                .ifPresent(status -> goalTracked.countDown()));
+
+        try {
+            final boolean serverStarted = this.futureBasedClientNode.waitForClientStartAndServerConnection(TIMEOUT, TIME_UNIT);
+            Assert.assertTrue("Was not connected. Elapsed Time:" + stopwatch.elapsed(TIME_UNIT) + " timeout:" + TIMEOUT, serverStarted);
+
+            final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> cancelledGoalFuture =
+                    this.futureBasedClientNode.invoke(TestInputs.HUGE_INPUT);
+            final boolean trackedGoalObserved = goalTracked.await(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertTrue("The goal was never observed as tracked before cancel-all", trackedGoalObserved);
+
+            final GoalID cancelAllGoalId = this.futureBasedClientNode.getActionClient().newGoalMessage().getGoalId();
+            cancelAllGoalId.setId("");
+            cancelAllGoalId.setStamp(new Time());
+            final boolean cancelAllSent = this.futureBasedClientNode.getActionClient().sendCancelInternal(cancelAllGoalId);
+            Assert.assertTrue("Cancel-all request was not published", cancelAllSent);
+
+            final FibonacciActionResult cancelledGoalResult =
+                    cancelledGoalFuture.get(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertNotNull("Cancelled result should not be null", cancelledGoalResult);
+            Assert.assertEquals("Cancel-all should preempt the tracked goal",
+                    GoalStatus.PREEMPTED, cancelledGoalResult.getStatus().getStatus());
+            Assert.assertFalse("Cancelled result should be incomplete",
+                    Arrays.equals(TestInputs.TEST_CORRECT_HUGE_INPUT_OUTPUT, cancelledGoalResult.getResult().getSequence()));
+            Assert.assertEquals("Cancelled future should be terminal", ClientState.DONE, cancelledGoalFuture.getCurrentState());
+
+            final ActionFuture<FibonacciActionGoal, FibonacciActionFeedback, FibonacciActionResult> futureGoal =
+                    this.futureBasedClientNode.invoke(TestInputs.TEST_INPUT);
+            final FibonacciActionResult futureGoalResult =
+                    futureGoal.get(TIMEOUT - stopwatch.elapsed(TIME_UNIT), TIME_UNIT);
+            Assert.assertNotNull("Future result should not be null", futureGoalResult);
+            Assert.assertTrue("Future goal should still succeed after cancel-all",
+                    Arrays.equals(futureGoalResult.getResult().getSequence(), TestInputs.TEST_CORRECT_OUTPUT));
         } catch (final Exception exception) {
             Assert.fail(ExceptionUtils.getStackTrace(exception));
         }


### PR DESCRIPTION
## Summary

`ActionServer` did not fully match ROS1 `actionlib` when a cancel arrived before the server had started tracking the goal.

That behavior was already visible in the repo:
- cancel flows were already covered by tests such as `WaitMethodsClientServerTest`
- `FibonacciActionLibServer` already had its own helper-side workaround to remember cancel state
- `AsyncGoalRunnerActionLibServer` exposed the gap more directly because it did not keep the same extra bookkeeping

This PR moves that behavior into the shared `ActionServer` so early-cancel handling is no longer implemented differently depending on which test helper is used.

Fixes #13

## What was already there

Before this PR:
- normal goal/cancel flows already existed in the test suite
- `WaitMethodsClientServerTest` already exercised cancellation behavior
- `FibonacciActionLibServer` already worked around early cancel handling in helper code
- `AsyncGoalRunnerActionLibServer` showed that the base server behavior was still incomplete

This PR moves custom-server side early-cancel handling in the library and adds extra functionality.

## What changed

- moved early-cancel handling into the base `ActionServer`
- remember unmatched exact goal-ID cancels and apply them when the goal arrives later
- apply timestamp-based cancels to matching older goals that arrive later
- support `cancel all` for currently tracked goals without incorrectly recalling future goals
- expire unmatched early-cancel placeholders after the normal retention window
- remove helper-specific cancel bookkeeping from the custom test servers
- update `AsyncGoalRunnerActionLibServer` to act as a regression path instead of a known-broken path
- harden duplicate-goal-ID handling so duplicate arrivals do not mutate already tracked goal metadata

## Test coverage

Added or updated coverage for:
- normal goal handling
- cancel after a goal has already started
- exact-ID cancel before goal arrival
- timestamp-based cancel before goal arrival
- `cancel all` for tracked goals without affecting future goals
- cleanup of unmatched early-cancel placeholders
- duplicate goal-ID handling
- connected client/server behavior where goal and cancel may arrive in either order on separate ROS topics

Verified with:
- `ActionServerTest`
- `ClientServerFeedbackTest`
- `WaitMethodsClientServerTest`
- `FibonacciFutureBasedClientNodeTest`
- `ActionServerResultStatusCompatibilityTest`
- `ActionServerTerminalStatusRetentionTest`
- `ActionClientFutureLifecycleTest`


